### PR TITLE
Adds Vagrant + Libvirt support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Cloud.
 * [x] Vagrant + VMWare support
 * [ ] Vagrant + Parallels support
 * [ ] Vagrant + Microsoft Hyper-V support
+* [x] Vagrant + Libvirt support
 * [ ] AWS support
 * [ ] Google Cloud support
 * [ ] Microsoft Azure support
@@ -35,6 +36,12 @@ Build a VMWare box:
 $ packer build -only=vmware-iso.almalinux-8 almalinux-8.pkr.hcl
 ```
 
+Build a Libvirt box:
+
+```sh
+$ packer build -only=qemu.almalinux-8 almalinux-8.pkr.hcl
+```
+
 
 ## Requirements
 
@@ -42,6 +49,7 @@ $ packer build -only=vmware-iso.almalinux-8 almalinux-8.pkr.hcl
 * [Ansible](https://www.ansible.com/)
 * [VirtualBox](https://www.virtualbox.org/) (for VirtualBox images only)
 * [VMWare Workstation](https://www.vmware.com/products/workstation-pro.html) (for VMWare images only)
+* [QEMU](https://www.qemu.org/) (for Libvirt images only)
 
 
 ## License

--- a/almalinux-8.pkr.hcl
+++ b/almalinux-8.pkr.hcl
@@ -110,7 +110,14 @@ build {
 
   post-processor "vagrant" {
     compression_level = "9"
-    vagrantfile_template = "tpl/vagrantfile.tpl"
     output = "almalinux-8-x86_64.{{isotime \"20060102\"}}.{{.Provider}}.box"
+    except = ["qemu.almalinux-8"]
+  }
+
+  post-processor "vagrant" {
+    compression_level = "9"
+    vagrantfile_template = "tpl/vagrant/vagrantfile-libvirt.tpl"
+    output = "almalinux-8-x86_64.{{isotime \"20060102\"}}.{{.Provider}}.box"
+    only = ["qemu.almalinux-8"]
   }
 }

--- a/almalinux-8.pkr.hcl
+++ b/almalinux-8.pkr.hcl
@@ -68,8 +68,34 @@ source "vmware-iso" "almalinux-8" {
 }
 
 
+source "qemu" "almalinux-8" {
+  iso_checksum       = var.iso_checksum
+  iso_url            = var.iso_url
+  shutdown_command   = var.shutdown_command
+  accelerator        = "kvm"
+  http_directory     = var.http_directory
+  ssh_username       = var.ssh_username
+  ssh_password       = var.ssh_password
+  ssh_timeout        = var.ssh_timeout
+  cpus               = var.cpus
+  disk_interface     = "virtio-scsi"
+  disk_size          = var.disk_size
+  disk_cache         = "unsafe"
+  disk_discard       = "unmap"
+  disk_detect_zeroes = "unmap"
+  disk_compression   = true
+  format             = "qcow2"
+  headless           = var.headless
+  memory             = var.memory
+  net_device         = "virtio-net"
+  qemu_binary        = "/usr/libexec/qemu-kvm"
+  vm_name            = "almalinux-8"
+  boot_wait          = var.boot_wait
+  boot_command       = var.boot_command
+}
+
 build {
-  sources = ["sources.virtualbox-iso.almalinux-8", "sources.vmware-iso.almalinux-8"]
+  sources = ["sources.virtualbox-iso.almalinux-8", "sources.vmware-iso.almalinux-8", "sources.qemu.almalinux-8"]
 
   provisioner "ansible" {
     playbook_file = "./ansible/vagrant-box.yml"
@@ -84,6 +110,7 @@ build {
 
   post-processor "vagrant" {
     compression_level = "9"
+    vagrantfile_template = "tpl/vagrantfile.tpl"
     output = "almalinux-8-x86_64.{{isotime \"20060102\"}}.{{.Provider}}.box"
   }
 }

--- a/ansible/roles/qemu_guest/README.md
+++ b/ansible/roles/qemu_guest/README.md
@@ -1,0 +1,3 @@
+# qemu_guest
+
+An Ansible role that installs `qemu-guest-agent` and `rsync` on a virtual machine.

--- a/ansible/roles/qemu_guest/meta/main.yml
+++ b/ansible/roles/qemu_guest/meta/main.yml
@@ -1,0 +1,16 @@
+galaxy_info:
+  role_name: qemu_guest
+  author: Elkhan Mammadli
+  description: Installs qemu-guest-agent
+  license: MIT
+  min_ansible_version: 2.5
+  platforms:
+    - name: EL
+      versions:
+        - 8
+  galaxy_tags:
+    - guest
+    - system
+    - qemu
+
+dependencies: []

--- a/ansible/roles/qemu_guest/meta/main.yml
+++ b/ansible/roles/qemu_guest/meta/main.yml
@@ -1,7 +1,7 @@
 galaxy_info:
   role_name: qemu_guest
   author: Elkhan Mammadli
-  description: Installs qemu-guest-agent
+  description: Installs qemu-guest-agent and rsync
   license: MIT
   min_ansible_version: 2.5
   platforms:

--- a/ansible/roles/qemu_guest/tasks/main.yml
+++ b/ansible/roles/qemu_guest/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Install qemu-guest-agent and rsync
+  dnf:
+    name:
+      - qemu-guest-agent
+      - rsync
+    state: latest

--- a/ansible/vagrant-box.yml
+++ b/ansible/vagrant-box.yml
@@ -10,5 +10,7 @@
       when: packer_provider == 'virtualbox-iso'
     - role: vmware_guest
       when: packer_provider == 'vmware-iso'
+    - role: qemu_guest
+      when: packer_provider == 'qemu'
     - install_vagrant_key
     - cleanup_vm

--- a/tpl/vagrant/vagrantfile-libvirt.tpl
+++ b/tpl/vagrant/vagrantfile-libvirt.tpl
@@ -10,3 +10,4 @@ Vagrant.configure("2") do |config|
     libvirt.storage_pool_name = "default"
   end
 end
+

--- a/tpl/vagrantfile.tpl
+++ b/tpl/vagrantfile.tpl
@@ -1,0 +1,12 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.synced_folder ".", "/vagrant", type: "rsync"
+  config.vm.provider :libvirt do |libvirt|
+    libvirt.driver = "kvm"
+    libvirt.connect_via_ssh = false
+    libvirt.username = "root"
+    libvirt.storage_pool_name = "default"
+  end
+end


### PR DESCRIPTION
Closes #5 

**Info**: qemu-guest-agent and rsync packages installed.

**Built on AlmaLinux OS 8.3 RC (Purple Manul) x86_64:**

* packer: 1.7.0-1 `@Hashicorp Stable RPM repo`
* ansible: 2.9.18-1.el8 `@epel`
* qemu: 15:4.2.0-34.module_el8.3.0+2048+e7a0a3ea.1 `@appstream`

**Tested on Fedora Workstation release 33 (Thirty Three) x86_64:**

 * vagrant: 2.2.14 `@Hashicorp Stable RPM repo`
 *  vagrant-libvirt: (0.3.0, global) `@vagrant plugin install vagrant-libvirt`
 
 **Box:** [lkhn/almalinux-8](https://app.vagrantup.com/lkhn/boxes/almalinux-8)
