### PR TITLE
Fix sssd failure

### DIFF
--- a/ansible/roles/cleanup_vm/tasks/main.yml
+++ b/ansible/roles/cleanup_vm/tasks/main.yml
@@ -65,11 +65,12 @@
     - /var/log/anaconda
     - /var/log/qemu-ga
     - /var/log/tuned
-    - /var/log/sssd
 
 - name: Find log files.
   find:
-    paths: /var/log
+    paths:
+      - /var/log
+      - /var/log/sssd
     patterns: '*log,*.old,*.log.gz,*.[0-9],*.gz,*-????????'
   register: log_files
 


### PR DESCRIPTION
The service cannot create its log folder at the first boot. Remove log files instead of the directory

Signed-off-by: Elkhan Mammadli <elkhan.mammadli@protonmail.com>