### PR TITLE
Set QEMU path accordingly to the EL systems

### DIFF
--- a/almalinux-8-aws-stage1.pkr.hcl
+++ b/almalinux-8-aws-stage1.pkr.hcl
@@ -60,6 +60,7 @@ source "qemu" "almalinux-8-aws-stage1" {
   headless           = var.headless
   memory             = var.memory
   net_device         = "virtio-net"
+  qemu_binary        = "/usr/libexec/qemu-kvm" # Comment it if your system using qemu-system-x86_64
   vm_name            = "almalinux-8-AWS-8.4.x86_64.raw"
   boot_wait          = var.boot_wait
   boot_command       = var.aws_boot_command

--- a/almalinux-8-digitalocean.pkr.hcl
+++ b/almalinux-8-digitalocean.pkr.hcl
@@ -32,6 +32,7 @@ source "qemu" "almalinux-8-digitalocean-x86_64" {
   headless           = var.headless
   memory             = var.memory
   net_device         = "virtio-net"
+  qemu_binary        = "/usr/libexec/qemu-kvm" # Comment it if your system using qemu-system-x86_64
   vm_name            = "almalinux-8-DigitalOcean-8.4.x86_64.qcow2"
   boot_wait          = var.boot_wait
   boot_command       = var.gencloud_boot_command

--- a/almalinux-8-gencloud.pkr.hcl
+++ b/almalinux-8-gencloud.pkr.hcl
@@ -22,6 +22,7 @@ source "qemu" "almalinux-8-gencloud-x86_64" {
   headless           = var.headless
   memory             = var.memory
   net_device         = "virtio-net"
+  qemu_binary        = "/usr/libexec/qemu-kvm" # Comment it if your system using qemu-system-x86_64
   vm_name            = "almalinux-8-GenericCloud-8.4.x86_64.qcow2"
   boot_wait          = var.boot_wait
   boot_command       = var.gencloud_boot_command

--- a/almalinux-8-vagrant.pkr.hcl
+++ b/almalinux-8-vagrant.pkr.hcl
@@ -94,6 +94,7 @@ source "qemu" "almalinux-8" {
   headless           = var.headless
   memory             = var.memory
   net_device         = "virtio-net"
+  qemu_binary        = "/usr/libexec/qemu-kvm" # Comment it if your system using qemu-system-x86_64
   vm_name            = "almalinux-8"
   boot_wait          = var.boot_wait
   boot_command       = var.vagrant_boot_command


### PR DESCRIPTION
Since the default host for building the images is EL.
Add qemu_binary option from qemu-system-x86_64(default) to /usr/libexec/qemu-kvm.
Fix Failed creating Qemu driver: exec: "qemu-system-x86_64": executable file not found in $PATH on EL systems.

Signed-off-by: Elkhan Mammadli <elkhan.mammadli@protonmail.com>