### PR TITLE
Set QEMU path as variable

### DIFF
--- a/almalinux-8-aws-stage1.pkr.hcl
+++ b/almalinux-8-aws-stage1.pkr.hcl
@@ -60,6 +60,7 @@ source "qemu" "almalinux-8-aws-stage1" {
   headless           = var.headless
   memory             = var.memory
   net_device         = "virtio-net"
+  qemu_binary        = var.qemu_binary
   vm_name            = "almalinux-8-AWS-8.4.x86_64.raw"
   boot_wait          = var.boot_wait
   boot_command       = var.aws_boot_command

--- a/almalinux-8-digitalocean.pkr.hcl
+++ b/almalinux-8-digitalocean.pkr.hcl
@@ -32,6 +32,7 @@ source "qemu" "almalinux-8-digitalocean-x86_64" {
   headless           = var.headless
   memory             = var.memory
   net_device         = "virtio-net"
+  qemu_binary        = var.qemu_binary
   vm_name            = "almalinux-8-DigitalOcean-8.4.x86_64.qcow2"
   boot_wait          = var.boot_wait
   boot_command       = var.gencloud_boot_command

--- a/almalinux-8-gencloud.pkr.hcl
+++ b/almalinux-8-gencloud.pkr.hcl
@@ -22,6 +22,7 @@ source "qemu" "almalinux-8-gencloud-x86_64" {
   headless           = var.headless
   memory             = var.memory
   net_device         = "virtio-net"
+  qemu_binary        = var.qemu_binary
   vm_name            = "almalinux-8-GenericCloud-8.4.x86_64.qcow2"
   boot_wait          = var.boot_wait
   boot_command       = var.gencloud_boot_command

--- a/almalinux-8-vagrant.pkr.hcl
+++ b/almalinux-8-vagrant.pkr.hcl
@@ -94,6 +94,7 @@ source "qemu" "almalinux-8" {
   headless           = var.headless
   memory             = var.memory
   net_device         = "virtio-net"
+  qemu_binary        = var.qemu_binary
   vm_name            = "almalinux-8"
   boot_wait          = var.boot_wait
   boot_command       = var.vagrant_boot_command

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -13,6 +13,7 @@ variables {
   http_directory        = "http"
   ssh_timeout           = "3600s"
   root_shutdown_command = "/sbin/shutdown -hP now"
+  qemu_binary           = ""
   //
   // AWS specific variables
   //


### PR DESCRIPTION
Gives us the flexibility to run the QEMU builds on the systems when the QEMU executable is not available as a qemu-system-x86_64 (i.e. EL)
Fixes "Failed creating Qemu driver: exec: "qemu-system-x86_64": executable file not found in $PATH" on EL

Signed-off-by: Elkhan Mammadli <elkhan.mammadli@protonmail.com>