### PR TITLE
Add Architecture tag for AMI

### DIFF
--- a/almalinux-8-aws-stage2.pkr.hcl
+++ b/almalinux-8-aws-stage2.pkr.hcl
@@ -19,8 +19,9 @@ source "amazon-chroot" "almalinux-8-aws-stage2" {
   ami_virtualization_type = "hvm"
   ami_regions             = ["us-east-1"]
   tags = {
-    Name    = "${var.aws_ami_name_x86_64}",
-    Version = "${var.aws_ami_version}"
+    Name         = "${var.aws_ami_name_x86_64}",
+    Version      = "${var.aws_ami_version}",
+    Architecture = "${var.aws_ami_architecture}"
   }
   region          = "us-east-1"
   device_path     = "/dev/xvdb"

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -32,6 +32,7 @@ variables {
   aws_ami_description_x86_64  = "Official AlmaLinux OS 8.4 x86_64 image"
   aws_ami_description_aarch64 = "Official AlmaLinux OS 8.4 aarch64 image"
   aws_ami_version             = "8.4.{{isotime \"20060102\"}}"
+  aws_ami_architecture        = "x86_64"
   //
   // DigitalOcean variables
   //


### PR DESCRIPTION
* Add Architecture tag for AMI for dynamic Architecture support on aws_ami_mirror.py tool 1/2

Signed-off-by: Elkhan Mammadli <elkhan.mammadli@protonmail.com>