### PR TITLE
Adds python3-libselinux dependency to install_vagrant_key role

### DIFF
--- a/ansible/roles/install_vagrant_key/tasks/main.yml
+++ b/ansible/roles/install_vagrant_key/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Install python3-libselinux
+  dnf:
+    name: python3-libselinux
+    state: present
+
 - name: Install Vagrant public SSH key
   ansible.posix.authorized_key:
     user: vagrant


### PR DESCRIPTION
Without that dependency the install_vagrant_key role fails
on EL9 systems. On EL8 systems it is installed by default.