### PR TITLE
Move DNS Cleanup task to the cleanup_vm role

### DIFF
--- a/ansible/roles/cleanup_vm/tasks/main.yml
+++ b/ansible/roles/cleanup_vm/tasks/main.yml
@@ -47,6 +47,7 @@
   command: "truncate -s 0 {{ item }}"
   loop:
     - /etc/machine-id
+    - /etc/resolv.conf
     - /var/log/audit/audit.log
     - /var/log/wtmp
     - /var/log/lastlog

--- a/ansible/roles/gencloud_guest/tasks/main.yml
+++ b/ansible/roles/gencloud_guest/tasks/main.yml
@@ -75,9 +75,6 @@
     - 'timeout 300;'
     - 'retry 60;'
 
-- name: Empty /etc/resolv.conf
-  command: truncate -s 0 /etc/resolv.conf
-
 - name: Set infra yum variable to 'genclo'
   replace:
     path: /etc/yum/vars/infra


### PR DESCRIPTION
This change makes it easy to customize Generic Cloud images. Before
this change, the user should add their package installation or network
related tasks before this task to avoid any name resolution errors
which is was reported by the community members that could be hard find
the reason for the issue.

Signed-off-by: Elkhan Mammadli <elkhan.mammadli@protonmail.com>