### PR TITLE
Add UEFI support to Generic Cloud on x86_64

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ AlmaLinux OS images for various cloud platforms.
 * [x] Google Cloud support
 * [x] Microsoft Azure support (#14)
 * [x] DigitalOcean support
-* [x] Generic Cloud / OpenStack `x86_64`, `aarch64` and `ppc64le` support
+* [x] Generic Cloud / OpenStack `x86_64`, `x86_64 UEFI`, `aarch64` and `ppc64le` support
 * [x] LXC/LXD support (#8)
 * [x] OpenNebula `x86_64` and `aarch64` support
 
@@ -242,6 +242,39 @@ In [Images >> Custom Images](https://cloud.digitalocean.com/images/custom_images
 $ packer build -only=qemu.almalinux-8-gencloud-x86_64 .
 ```
 
+`UEFI on x86_64`
+
+You need the `1.0.2` version of the [QEMU packer plugin](https://github.com/hashicorp/packer-plugin-qemu) and `edk2-ovmf`(RPM and ArchLinux)/`ovmf`(DEB) packages for the needed OVMF firmware files.
+
+```sh
+$ packer build -only=qemu.almalinux-8-gencloud-uefi-x86_64 .
+```
+
+`How to build UEFI images on EL8 systems`
+
+By default the `firmware_x86_64` packer variable set to use `/usr/share/OVMF/OVMF_CODE.fd`.
+The `OVMF_CODE.fd` is not present on the EL8 systems and the packer qemu plugin's VM doesn't boot with the `OVMF_CODE.secboot.fd`.
+Thanks to the Fedora edk2 package maintainer [kraxel](https://www.kraxel.org) for his [Qemu firmware repo](https://www.kraxel.org/repos/),
+You can use the latest build of the OVMF from the repo without overwriting the system's package manager provided firmware files.
+
+Add the repository:
+
+```sh
+$ dnf config-manager --add-repo=https://www.kraxel.org/repos/firmware.repo
+```
+
+Recreate the DNF cache and install UEFI firmware for x64 qemu guests (OVMF):
+
+```sh
+$ dnf makecache && dnf -y install edk2.git-ovmf-x64
+```
+
+Build UEFI Image on the EL8:
+
+```sh
+$ packer build -var qemu_binary="/usr/libexec/qemu-kvm" -var firmware_x86_64="/usr/share/edk2.git/ovmf-x64/OVMF_CODE-pure-efi.fd" -only=qemu.almalinux-8-gencloud-uefi-x86_64 .
+```
+
 `aarch64`
 ```sh
 $ packer build -only=qemu.almalinux-8-gencloud-aarch64 .
@@ -294,6 +327,7 @@ $ packer build -only=qemu.almalinux-8-opennebula-aarch64 .
 * [Parallels](https://www.parallels.com/) (for Parallels images only)
 * [VMWare Workstation](https://www.vmware.com/products/workstation-pro.html) (for VMWare images and Amazon AMI's only)
 * [QEMU](https://www.qemu.org/) (for Generic Cloud, Vagrant Libvirt, AWS AMI, OpenNebula and DigitalOcean images only)
+* [EDK II](https://github.com/tianocore/tianocore.github.io/wiki/OVMF) (for only UEFI supported `x86_64` ones and all `aarch64` images)
 
 
 ## References

--- a/almalinux-8-gencloud.pkr.hcl
+++ b/almalinux-8-gencloud.pkr.hcl
@@ -23,9 +23,36 @@ source "qemu" "almalinux-8-gencloud-x86_64" {
   memory             = var.memory
   net_device         = "virtio-net"
   qemu_binary        = var.qemu_binary
-  vm_name            = "almalinux-8-GenericCloud-8.5.x86_64.qcow2"
+  vm_name            = "AlmaLinux-8-GenericCloud-8.5-${formatdate("YYYYMMDD", timestamp())}.x86_64.qcow2"
   boot_wait          = var.boot_wait
   boot_command       = var.gencloud_boot_command_x86_64
+}
+
+source "qemu" "almalinux-8-gencloud-uefi-x86_64" {
+  iso_url            = var.iso_url_x86_64
+  iso_checksum       = var.iso_checksum_x86_64
+  shutdown_command   = var.root_shutdown_command
+  accelerator        = "kvm"
+  http_directory     = var.http_directory
+  ssh_username       = var.gencloud_ssh_username
+  ssh_password       = var.gencloud_ssh_password
+  ssh_timeout        = var.ssh_timeout
+  cpus               = var.cpus
+  firmware           = var.firmware_x86_64
+  disk_interface     = "virtio-scsi"
+  disk_size          = var.gencloud_disk_size
+  disk_cache         = "unsafe"
+  disk_discard       = "unmap"
+  disk_detect_zeroes = "unmap"
+  disk_compression   = true
+  format             = "qcow2"
+  headless           = var.headless
+  memory             = var.memory
+  net_device         = "virtio-net"
+  qemu_binary        = var.qemu_binary
+  vm_name            = "AlmaLinux-8-GenericCloud-UEFI-8.5-${formatdate("YYYYMMDD", timestamp())}.x86_64.qcow2"
+  boot_wait          = var.boot_wait
+  boot_command       = var.gencloud_boot_command_x86_64_uefi
 }
 
 
@@ -39,7 +66,7 @@ source "qemu" "almalinux-8-gencloud-aarch64" {
   ssh_password       = var.gencloud_ssh_password
   ssh_timeout        = var.ssh_timeout
   cpus               = var.cpus
-  firmware           = "/usr/share/AAVMF/AAVMF_CODE.fd"
+  firmware           = var.firmware_aarch64
   disk_interface     = "virtio-scsi"
   disk_size          = var.gencloud_disk_size
   disk_cache         = "unsafe"
@@ -52,7 +79,7 @@ source "qemu" "almalinux-8-gencloud-aarch64" {
   memory             = var.memory
   net_device         = "virtio-net"
   qemu_binary        = var.qemu_binary
-  vm_name            = "almalinux-8-GenericCloud-8.5.aarch64.qcow2"
+  vm_name            = "AlmaLinux-8-GenericCloud-8.5-${formatdate("YYYYMMDD", timestamp())}.aarch64.qcow2"
   boot_wait          = var.boot_wait
   boot_command       = var.gencloud_boot_command_aarch64
   qemuargs = [
@@ -83,7 +110,7 @@ source "qemu" "almalinux-8-gencloud-ppc64le" {
   memory             = var.memory
   net_device         = "virtio-net"
   qemu_binary        = var.qemu_binary
-  vm_name            = "almalinux-8-GenericCloud-8.5.ppc64le.qcow2"
+  vm_name            = "AlmaLinux-8-GenericCloud-8.5-${formatdate("YYYYMMDD", timestamp())}.ppc64le.qcow2"
   boot_wait          = var.gencloud_boot_wait_ppc64le
   boot_command       = var.gencloud_boot_command_ppc64le
   qemuargs = [
@@ -95,6 +122,7 @@ source "qemu" "almalinux-8-gencloud-ppc64le" {
 build {
   sources = [
     "qemu.almalinux-8-gencloud-x86_64",
+    "qemu.almalinux-8-gencloud-uefi-x86_64",
     "qemu.almalinux-8-gencloud-aarch64",
     "qemu.almalinux-8-gencloud-ppc64le"
   ]

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -18,6 +18,8 @@ variables {
   ssh_timeout           = "3600s"
   root_shutdown_command = "/sbin/shutdown -hP now"
   qemu_binary           = ""
+  firmware_x86_64       = "/usr/share/OVMF/OVMF_CODE.fd"
+  firmware_aarch64      = "/usr/share/AAVMF/AAVMF_CODE.fd"
   //
   // AWS specific variables
   //
@@ -53,6 +55,14 @@ variables {
   //
   gencloud_boot_command_x86_64 = [
     "<tab> inst.text net.ifnames=0 inst.gpt inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-8.gencloud-x86_64.ks<enter><wait>"
+  ]
+  gencloud_boot_command_x86_64_uefi = [
+    "c<wait>",
+    "linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=AlmaLinux-8-5-x86_64-dvd ro",
+    "inst.text biosdevname=0 net.ifnames=0 ",
+    "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-8.gencloud-x86_64.ks<enter>",
+    "initrdefi /images/pxeboot/initrd.img<enter>",
+    "boot<enter><wait>"
   ]
   gencloud_boot_command_aarch64 = [
     "c<wait>",

--- a/versions.pkr.hcl
+++ b/versions.pkr.hcl
@@ -2,7 +2,7 @@ packer {
   required_version = ">= 1.7.0"
   required_plugins {
     qemu = {
-      version = ">= 1.0.0"
+      version = "1.0.2"
       source  = "github.com/hashicorp/qemu"
     }
     virtualbox = {


### PR DESCRIPTION
* Added UEFI support to the Generic Cloud (OpenStack compatible) image
on the x86_64.
* Changed the name of the output image file with a timestamp in the
"YYYYMMDD" format and adjust naming scheme with repository one.

close: #74 

Signed-off-by: Elkhan Mammadli <elkhan.mammadli@protonmail.com>