### PR TITLE
AlmaLinux OS 9 support and general enhancements

### DIFF
--- a/almalinux-8-aws-stage1.pkr.hcl
+++ b/almalinux-8-aws-stage1.pkr.hcl
@@ -3,9 +3,9 @@
  */
 
 source "vmware-iso" "almalinux-8-aws-stage1" {
-  iso_url          = var.iso_url_x86_64
-  iso_checksum     = var.iso_checksum_x86_64
-  boot_command     = var.aws_boot_command
+  iso_url          = var.iso_url_8_x86_64
+  iso_checksum     = var.iso_checksum_8_x86_64
+  boot_command     = var.aws_boot_command_8
   boot_wait        = var.boot_wait
   cpus             = var.cpus
   memory           = var.memory
@@ -31,8 +31,8 @@ source "vmware-iso" "almalinux-8-aws-stage1" {
 
 
 source "qemu" "almalinux-8-aws-stage1" {
-  iso_url            = var.iso_url_x86_64
-  iso_checksum       = var.iso_checksum_x86_64
+  iso_url            = var.iso_url_8_x86_64
+  iso_checksum       = var.iso_checksum_8_x86_64
   shutdown_command   = var.root_shutdown_command
   accelerator        = "kvm"
   http_directory     = var.http_directory
@@ -53,7 +53,7 @@ source "qemu" "almalinux-8-aws-stage1" {
   qemu_binary        = var.qemu_binary
   vm_name            = "almalinux-8-AWS-8.5.x86_64.raw"
   boot_wait          = var.boot_wait
-  boot_command       = var.aws_boot_command
+  boot_command       = var.aws_boot_command_8
 }
 
 

--- a/almalinux-8-digitalocean.pkr.hcl
+++ b/almalinux-8-digitalocean.pkr.hcl
@@ -3,8 +3,8 @@
  */
 
 source "qemu" "almalinux-8-digitalocean-x86_64" {
-  iso_url            = var.iso_url_x86_64
-  iso_checksum       = var.iso_checksum_x86_64
+  iso_url            = var.iso_url_8_x86_64
+  iso_checksum       = var.iso_checksum_8_x86_64
   shutdown_command   = var.root_shutdown_command
   accelerator        = "kvm"
   http_directory     = var.http_directory
@@ -25,7 +25,7 @@ source "qemu" "almalinux-8-digitalocean-x86_64" {
   qemu_binary        = var.qemu_binary
   vm_name            = "almalinux-8-DigitalOcean-8.5.x86_64.qcow2"
   boot_wait          = var.boot_wait
-  boot_command       = var.gencloud_boot_command_x86_64
+  boot_command       = var.gencloud_boot_command_8_x86_64
 }
 
 

--- a/almalinux-8-opennebula.pkr.hcl
+++ b/almalinux-8-opennebula.pkr.hcl
@@ -3,8 +3,8 @@
  */
 
 source "qemu" "almalinux-8-opennebula-x86_64" {
-  iso_url            = var.iso_url_x86_64
-  iso_checksum       = var.iso_checksum_x86_64
+  iso_url            = var.iso_url_8_x86_64
+  iso_checksum       = var.iso_checksum_8_x86_64
   shutdown_command   = var.root_shutdown_command
   accelerator        = "kvm"
   http_directory     = var.http_directory
@@ -25,13 +25,13 @@ source "qemu" "almalinux-8-opennebula-x86_64" {
   qemu_binary        = var.qemu_binary
   vm_name            = "almalinux-8-OpenNebula-8.5.x86_64.qcow2"
   boot_wait          = var.boot_wait
-  boot_command       = var.opennebula_boot_command_x86_64
+  boot_command       = var.opennebula_boot_command_8_x86_64
 }
 
 
 source "qemu" "almalinux-8-opennebula-aarch64" {
-  iso_url            = var.iso_url_aarch64
-  iso_checksum       = var.iso_checksum_aarch64
+  iso_url            = var.iso_url_8_aarch64
+  iso_checksum       = var.iso_checksum_8_aarch64
   shutdown_command   = var.root_shutdown_command
   accelerator        = "kvm"
   http_directory     = var.http_directory
@@ -39,7 +39,8 @@ source "qemu" "almalinux-8-opennebula-aarch64" {
   ssh_password       = var.gencloud_ssh_password
   ssh_timeout        = var.ssh_timeout
   cpus               = var.cpus
-  firmware           = "/usr/share/AAVMF/AAVMF_CODE.fd"
+  firmware           = var.firmware_aarch64
+  use_pflash         = false
   disk_interface     = "virtio-scsi"
   disk_size          = var.gencloud_disk_size
   disk_cache         = "unsafe"
@@ -54,7 +55,7 @@ source "qemu" "almalinux-8-opennebula-aarch64" {
   qemu_binary        = var.qemu_binary
   vm_name            = "almalinux-8-OpenNebula-8.5.aarch64.qcow2"
   boot_wait          = var.boot_wait
-  boot_command       = var.opennebula_boot_command_aarch64
+  boot_command       = var.opennebula_boot_command_8_aarch64
   qemuargs = [
     ["-cpu", "max"],
     ["-boot", "strict=on"],

--- a/almalinux-8-vagrant.pkr.hcl
+++ b/almalinux-8-vagrant.pkr.hcl
@@ -3,9 +3,9 @@
  */
 
 source "hyperv-iso" "almalinux-8" {
-  iso_url               = var.iso_url_x86_64
-  iso_checksum          = var.iso_checksum_x86_64
-  boot_command          = var.vagrant_efi_boot_command
+  iso_url               = var.iso_url_8_x86_64
+  iso_checksum          = var.iso_checksum_8_x86_64
+  boot_command          = var.vagrant_efi_boot_command_8_x86_64
   boot_wait             = var.boot_wait
   generation            = 2
   switch_name           = var.hyperv_switch_name
@@ -25,14 +25,14 @@ source "hyperv-iso" "almalinux-8" {
 
 
 source "parallels-iso" "almalinux-8" {
-  boot_command           = var.vagrant_boot_command
+  boot_command           = var.vagrant_boot_command_8_x86_64
   boot_wait              = var.boot_wait
   cpus                   = var.cpus
   disk_size              = var.vagrant_disk_size
   guest_os_type          = "centos"
   http_directory         = var.http_directory
-  iso_checksum           = var.iso_checksum_x86_64
-  iso_url                = var.iso_url_x86_64
+  iso_checksum           = var.iso_checksum_8_x86_64
+  iso_url                = var.iso_url_8_x86_64
   memory                 = var.memory
   parallels_tools_flavor = var.parallels_tools_flavor_x86_64
   shutdown_command       = var.vagrant_shutdown_command
@@ -43,9 +43,9 @@ source "parallels-iso" "almalinux-8" {
 
 
 source "virtualbox-iso" "almalinux-8" {
-  iso_url              = var.iso_url_x86_64
-  iso_checksum         = var.iso_checksum_x86_64
-  boot_command         = var.vagrant_boot_command
+  iso_url              = var.iso_url_8_x86_64
+  iso_checksum         = var.iso_checksum_8_x86_64
+  boot_command         = var.vagrant_boot_command_8_x86_64
   boot_wait            = var.boot_wait
   cpus                 = var.cpus
   memory               = var.memory
@@ -66,9 +66,9 @@ source "virtualbox-iso" "almalinux-8" {
 
 
 source "vmware-iso" "almalinux-8" {
-  iso_url          = var.iso_url_x86_64
-  iso_checksum     = var.iso_checksum_x86_64
-  boot_command     = var.vagrant_boot_command
+  iso_url          = var.iso_url_8_x86_64
+  iso_checksum     = var.iso_checksum_8_x86_64
+  boot_command     = var.vagrant_boot_command_8_x86_64
   boot_wait        = var.boot_wait
   cpus             = var.cpus
   memory           = var.memory
@@ -93,8 +93,8 @@ source "vmware-iso" "almalinux-8" {
 
 
 source "qemu" "almalinux-8" {
-  iso_checksum       = var.iso_checksum_x86_64
-  iso_url            = var.iso_url_x86_64
+  iso_checksum       = var.iso_checksum_8_x86_64
+  iso_url            = var.iso_url_8_x86_64
   shutdown_command   = var.vagrant_shutdown_command
   accelerator        = "kvm"
   http_directory     = var.http_directory
@@ -115,7 +115,7 @@ source "qemu" "almalinux-8" {
   qemu_binary        = var.qemu_binary
   vm_name            = "almalinux-8"
   boot_wait          = var.boot_wait
-  boot_command       = var.vagrant_boot_command
+  boot_command       = var.vagrant_boot_command_8_x86_64
 }
 
 

--- a/almalinux-9-gencloud.pkr.hcl
+++ b/almalinux-9-gencloud.pkr.hcl
@@ -1,10 +1,10 @@
 /*
- * AlmaLinux OS 8 Packer template for building Generic Cloud (OpenStack compatible) images.
+ * AlmaLinux OS 9 Packer template for building Generic Cloud (OpenStack compatible) images.
  */
 
-source "qemu" "almalinux-8-gencloud-x86_64" {
-  iso_url            = var.iso_url_8_x86_64
-  iso_checksum       = var.iso_checksum_8_x86_64
+source "qemu" "almalinux-9-gencloud-bios-x86_64" {
+  iso_url            = var.iso_url_9_x86_64
+  iso_checksum       = var.iso_checksum_9_x86_64
   shutdown_command   = var.root_shutdown_command
   accelerator        = "kvm"
   http_directory     = var.http_directory
@@ -20,17 +20,21 @@ source "qemu" "almalinux-8-gencloud-x86_64" {
   disk_compression   = true
   format             = "qcow2"
   headless           = var.headless
+  machine_type       = "q35"
   memory             = var.memory
   net_device         = "virtio-net"
   qemu_binary        = var.qemu_binary
-  vm_name            = "AlmaLinux-8-GenericCloud-8.5-${formatdate("YYYYMMDD", timestamp())}.x86_64.qcow2"
+  vm_name            = "AlmaLinux-9-GenericCloud-BIOS-9-beta${formatdate("YYYYMMDD", timestamp())}.x86_64.qcow2"
   boot_wait          = var.boot_wait
-  boot_command       = var.gencloud_boot_command_8_x86_64
+  boot_command       = var.gencloud_boot_command_9_x86_64_bios
+  qemuargs = [
+    ["-cpu", "host"]
+  ]
 }
 
-source "qemu" "almalinux-8-gencloud-uefi-x86_64" {
-  iso_url            = var.iso_url_8_x86_64
-  iso_checksum       = var.iso_checksum_8_x86_64
+source "qemu" "almalinux-9-gencloud-x86_64" {
+  iso_url            = var.iso_url_9_x86_64
+  iso_checksum       = var.iso_checksum_9_x86_64
   shutdown_command   = var.root_shutdown_command
   accelerator        = "kvm"
   http_directory     = var.http_directory
@@ -48,18 +52,22 @@ source "qemu" "almalinux-8-gencloud-uefi-x86_64" {
   disk_compression   = true
   format             = "qcow2"
   headless           = var.headless
+  machine_type       = "q35"
   memory             = var.memory
   net_device         = "virtio-net"
   qemu_binary        = var.qemu_binary
-  vm_name            = "AlmaLinux-8-GenericCloud-UEFI-8.5-${formatdate("YYYYMMDD", timestamp())}.x86_64.qcow2"
+  vm_name            = "AlmaLinux-9-GenericCloud-9.0-beta-1-${formatdate("YYYYMMDD", timestamp())}.x86_64.qcow2"
   boot_wait          = var.boot_wait
-  boot_command       = var.gencloud_boot_command_8_x86_64_uefi
+  boot_command       = var.gencloud_boot_command_9_x86_64
+  qemuargs = [
+    ["-cpu", "host"]
+  ]
 }
 
 
-source "qemu" "almalinux-8-gencloud-aarch64" {
-  iso_url            = var.iso_url_8_aarch64
-  iso_checksum       = var.iso_checksum_8_aarch64
+source "qemu" "almalinux-9-gencloud-aarch64" {
+  iso_url            = var.iso_url_9_aarch64
+  iso_checksum       = var.iso_checksum_9_aarch64
   shutdown_command   = var.root_shutdown_command
   accelerator        = "kvm"
   http_directory     = var.http_directory
@@ -81,9 +89,9 @@ source "qemu" "almalinux-8-gencloud-aarch64" {
   memory             = var.memory
   net_device         = "virtio-net"
   qemu_binary        = var.qemu_binary
-  vm_name            = "AlmaLinux-8-GenericCloud-8.5-${formatdate("YYYYMMDD", timestamp())}.aarch64.qcow2"
+  vm_name            = "AlmaLinux-9-GenericCloud-9.0-beta-1-${formatdate("YYYYMMDD", timestamp())}.aarch64.qcow2"
   boot_wait          = var.boot_wait
-  boot_command       = var.gencloud_boot_command_8_aarch64
+  boot_command       = var.gencloud_boot_command_9_aarch64
   qemuargs = [
     ["-cpu", "max"],
     ["-boot", "strict=on"],
@@ -92,9 +100,9 @@ source "qemu" "almalinux-8-gencloud-aarch64" {
 }
 
 
-source "qemu" "almalinux-8-gencloud-ppc64le" {
-  iso_url            = var.iso_url_8_ppc64le
-  iso_checksum       = var.iso_checksum_8_ppc64le
+source "qemu" "almalinux-9-gencloud-ppc64le" {
+  iso_url            = var.iso_url_9_ppc64le
+  iso_checksum       = var.iso_checksum_9_ppc64le
   shutdown_command   = var.root_shutdown_command
   http_directory     = var.http_directory
   ssh_username       = var.gencloud_ssh_username
@@ -112,9 +120,9 @@ source "qemu" "almalinux-8-gencloud-ppc64le" {
   memory             = var.memory
   net_device         = "virtio-net"
   qemu_binary        = var.qemu_binary
-  vm_name            = "AlmaLinux-8-GenericCloud-8.5-${formatdate("YYYYMMDD", timestamp())}.ppc64le.qcow2"
+  vm_name            = "AlmaLinux-9-GenericCloud-9.0-beta-1-${formatdate("YYYYMMDD", timestamp())}.ppc64le.qcow2"
   boot_wait          = var.gencloud_boot_wait_ppc64le
-  boot_command       = var.gencloud_boot_command_8_ppc64le
+  boot_command       = var.gencloud_boot_command_9_ppc64le
   qemuargs = [
     ["-machine", "pseries,accel=kvm,kvm-type=HV"]
   ]
@@ -123,10 +131,10 @@ source "qemu" "almalinux-8-gencloud-ppc64le" {
 
 build {
   sources = [
-    "qemu.almalinux-8-gencloud-x86_64",
-    "qemu.almalinux-8-gencloud-uefi-x86_64",
-    "qemu.almalinux-8-gencloud-aarch64",
-    "qemu.almalinux-8-gencloud-ppc64le"
+    "qemu.almalinux-9-gencloud-bios-x86_64",
+    "qemu.almalinux-9-gencloud-x86_64",
+    "qemu.almalinux-9-gencloud-aarch64",
+    "qemu.almalinux-9-gencloud-ppc64le"
   ]
 
   provisioner "ansible" {

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,7 +1,8 @@
 ---
 collections:
-  - name: ansible.posix
-  - name: almalinux.ci
+  - ansible.posix
+  - almalinux.ci
+  - community.general
 
 roles:
-  - name: ezamriy.vbox_guest
+  - ezamriy.vbox_guest

--- a/ansible/roles/cleanup_vm/tasks/main.yml
+++ b/ansible/roles/cleanup_vm/tasks/main.yml
@@ -82,6 +82,17 @@
     state: absent
   loop: "{{ log_files.files }}"
 
+- name: Remove random-seed
+  file:
+    path: /var/lib/systemd/random-seed
+    state: absent
+
+- name: Disable root SSH login via password
+  file:
+    path: /etc/ssh/sshd_config.d/01-permitrootlogin.conf
+    state: absent
+  when: ansible_facts['distribution_major_version'] == '9'
+
 - name: Fill free space with zeroes
   shell: dd if=/dev/zero of=/zeroed_file bs=1M oflag=direct || rm -f /zeroed_file
 

--- a/ansible/roles/gencloud_guest/tasks/main.yml
+++ b/ansible/roles/gencloud_guest/tasks/main.yml
@@ -24,6 +24,8 @@
       - nfs-utils
       - rsync
       - tar
+      - tuned
+      - tcpdump
 
 - name: Find persistent-net.rules
   find:
@@ -67,19 +69,23 @@
     regexp: '^#?NAutoVTs=\d+'
     replace: 'NAutoVTs=0'
 
-- name: Configure dhclient
-  lineinfile:
-    path: /etc/dhcp/dhclient.conf
-    line: "{{ item }}"
-  with_items:
-    - 'timeout 300;'
-    - 'retry 60;'
+- name: Configure NetworkManager default DHCP timeout
+  community.general.ini_file:
+    path: /etc/NetworkManager/conf.d/dhcp.conf
+    section: connection
+    option: ipv4.dhcp-timeout
+    value: 300
+    owner: root
+    group: root
+    mode: 0644
+    seuser: system_u
 
 - name: Set infra yum variable to 'genclo'
   replace:
     path: /etc/yum/vars/infra
     regexp: '^(.*?)$'
     replace: 'genclo'
+  when: ansible_facts['distribution_major_version'] == '8'
 
 - name: Set default kernel package type to kernel
   replace:
@@ -108,6 +114,12 @@
     path: /etc/sudoers
     line: "almalinux\tALL=(ALL)\tNOPASSWD: ALL"
     state: present
+
+- name: Set virtual-guest as default profile for tuned
+  lineinfile:
+    path: /etc/tuned/active_profile
+    line: virtual-guest
+    create: yes
 
 - name: Regenerate the initramfs
   command: dracut -f --regenerate-all

--- a/http/almalinux-9.gencloud-aarch64.ks
+++ b/http/almalinux-9.gencloud-aarch64.ks
@@ -1,0 +1,60 @@
+# AlmaLinux 9 kickstart file for Generic Cloud (OpenStack) aarch64 image
+
+url --url https://repo.almalinux.org/almalinux/9.0-beta/BaseOS/aarch64/kickstart/
+repo --name=BaseOS --baseurl=https://repo.almalinux.org/almalinux/9.0-beta/BaseOS/aarch64/os/
+repo --name=AppStream --baseurl=https://repo.almalinux.org/almalinux/9.0-beta/AppStream/aarch64/os/
+
+text
+skipx
+eula --agreed
+firstboot --disabled
+
+lang C.UTF-8
+keyboard us
+timezone UTC --utc
+
+network --bootproto=dhcp
+firewall --enabled --service=ssh
+services --disabled="kdump" --enabled="chronyd,rsyslog,sshd"
+selinux --enforcing
+
+bootloader --timeout=1 --location=mbr --append="console=tty0 console=ttyS0,115200n8 no_timer_check crashkernel=auto net.ifnames=0"
+
+zerombr
+clearpart --all --initlabel
+part /boot/efi --size=200 --fstype=efi
+part /boot --size=500 --fstype=xfs
+part / --size=8000 --fstype=xfs
+
+rootpw --plaintext almalinux
+
+reboot --eject
+
+
+%packages --instLangs=en
+@core
+dracut-config-generic
+usermode
+-biosdevname
+-dnf-plugin-spacewalk
+-dracut-config-rescue
+-iprutils
+-iwl*-firmware
+-langpacks-*
+-mdadm
+-open-vm-tools
+-plymouth
+-rhn*
+%end
+
+
+# disable kdump service
+%addon com_redhat_kdump --disable
+%end
+
+%post --erroronfail
+
+# permit root login via SSH with password authetication
+echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/01-permitrootlogin.conf
+
+%end

--- a/http/almalinux-9.gencloud-ppc64le.ks
+++ b/http/almalinux-9.gencloud-ppc64le.ks
@@ -1,0 +1,60 @@
+# AlmaLinux 9 kickstart file for Generic Cloud (OpenStack) ppc64le image
+
+url --url https://repo.almalinux.org/almalinux/9.0-beta/BaseOS/ppc64le/kickstart/
+repo --name=BaseOS --baseurl=https://repo.almalinux.org/almalinux/9.0-beta/BaseOS/ppc64le/os/
+repo --name=AppStream --baseurl=https://repo.almalinux.org/almalinux/9.0-beta/AppStream/ppc64le/os/
+
+text
+skipx
+eula --agreed
+firstboot --disabled
+
+lang C.UTF-8
+keyboard us
+timezone UTC --utc
+
+network --bootproto=dhcp
+firewall --enabled --service=ssh
+services --disabled="kdump" --enabled="chronyd,rsyslog,sshd"
+selinux --enforcing
+
+bootloader --timeout=1 --location=mbr --append="console=tty0 console=ttyS0,115200n8 no_timer_check crashkernel=auto net.ifnames=0"
+
+zerombr
+clearpart --all --initlabel
+reqpart
+part /boot --size=500 --fstype=xfs
+part / --size=8000 --fstype=xfs
+
+rootpw --plaintext almalinux
+
+reboot --eject
+
+
+%packages --instLangs=en
+@core
+dracut-config-generic
+usermode
+-biosdevname
+-dnf-plugin-spacewalk
+-dracut-config-rescue
+-iprutils
+-iwl*-firmware
+-langpacks-*
+-mdadm
+-open-vm-tools
+-plymouth
+-rhn*
+%end
+
+
+# disable kdump service
+%addon com_redhat_kdump --disable
+%end
+
+%post --erroronfail
+
+# permit root login via SSH with password authetication
+echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/01-permitrootlogin.conf
+
+%end

--- a/http/almalinux-9.gencloud-x86_64-bios.ks
+++ b/http/almalinux-9.gencloud-x86_64-bios.ks
@@ -1,0 +1,51 @@
+# AlmaLinux 9 kickstart file for Generic Cloud (OpenStack) x86_64-v2 image
+
+url --url https://repo.almalinux.org/almalinux/9.0-beta/BaseOS/x86_64/kickstart/
+repo --name=BaseOS --baseurl=https://repo.almalinux.org/almalinux/9.0-beta/BaseOS/x86_64/os/
+repo --name=AppStream --baseurl=https://repo.almalinux.org/almalinux/9.0-beta/AppStream/x86_64/os/
+
+text
+skipx
+eula --agreed
+firstboot --disabled
+
+lang C.UTF-8
+keyboard us
+timezone UTC --utc
+
+network --bootproto=dhcp
+firewall --enabled --service=ssh
+services --disabled="kdump" --enabled="chronyd,rsyslog,sshd"
+selinux --enforcing
+
+bootloader --timeout=1 --location=mbr --append="console=ttyS0,115200n8 no_timer_check crashkernel=auto net.ifnames=0"
+zerombr
+clearpart --all --initlabel
+reqpart
+part / --fstype="xfs" --size=8000
+
+rootpw --plaintext almalinux
+
+reboot --eject
+
+
+%packages
+@core
+-biosdevname
+-open-vm-tools
+-plymouth
+-dnf-plugin-spacewalk
+-rhn*
+-iprutils
+-iwl*-firmware
+%end
+
+
+# disable kdump service
+%addon com_redhat_kdump --disable
+%end
+
+%post --erroronfail
+# permit root login via SSH with password authetication
+echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/01-permitrootlogin.conf
+%end

--- a/http/almalinux-9.gencloud-x86_64.ks
+++ b/http/almalinux-9.gencloud-x86_64.ks
@@ -1,0 +1,72 @@
+# AlmaLinux 9 kickstart file for Generic Cloud (OpenStack) x86-64-v2 image
+
+url --url https://repo.almalinux.org/almalinux/9.0-beta/BaseOS/x86_64/kickstart/
+repo --name=BaseOS --baseurl=https://repo.almalinux.org/almalinux/9.0-beta/BaseOS/x86_64/os/
+repo --name=AppStream --baseurl=https://repo.almalinux.org/almalinux/9.0-beta/AppStream/x86_64/os/
+
+text
+skipx
+eula --agreed
+firstboot --disabled
+
+lang C.UTF-8
+keyboard us
+timezone UTC --utc
+
+network --bootproto=dhcp
+firewall --enabled --service=ssh
+services --disabled="kdump" --enabled="chronyd,rsyslog,sshd"
+selinux --enforcing
+
+bootloader --timeout=1 --location=mbr --append="console=tty0 console=ttyS0,115200n8 no_timer_check crashkernel=auto net.ifnames=0"
+
+%pre --erroronfail
+
+parted -s -a optimal /dev/sda -- mklabel gpt
+parted -s -a optimal /dev/sda -- mkpart biosboot 1MiB 2MiB set 1 bios_grub on
+parted -s -a optimal /dev/sda -- mkpart '"EFI System Partition"' fat32 2MiB 202MiB set 2 esp on
+parted -s -a optimal /dev/sda -- mkpart boot xfs 202MiB 702MiB
+parted -s -a optimal /dev/sda -- mkpart root xfs 702MiB 100%
+
+%end
+
+part biosboot --fstype=biosboot --onpart=sda1
+part /boot/efi --fstype=efi --onpart=sda2
+part /boot --fstype=xfs --onpart=sda3
+part / --fstype=xfs --onpart=sda4
+
+rootpw --plaintext almalinux
+
+reboot --eject
+
+
+%packages --instLangs=en
+@core
+dracut-config-generic
+grub2-pc
+usermode
+-biosdevname
+-dnf-plugin-spacewalk
+-dracut-config-rescue
+-iprutils
+-iwl*-firmware
+-langpacks-*
+-mdadm
+-open-vm-tools
+-plymouth
+-rhn*
+%end
+
+
+# disable kdump service
+%addon com_redhat_kdump --disable
+%end
+
+%post --erroronfail
+
+grub2-install --target=i386-pc /dev/sda
+
+# permit root login via SSH with password authetication
+echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/01-permitrootlogin.conf
+
+%end

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -2,28 +2,34 @@ variables {
   //
   // common variables
   //
-  iso_url_x86_64        = "https://repo.almalinux.org/almalinux/8.5/isos/x86_64/AlmaLinux-8.5-x86_64-boot.iso"
-  iso_checksum_x86_64   = "file:https://repo.almalinux.org/almalinux/8.5/isos/x86_64/CHECKSUM"
-  iso_url_aarch64       = "https://repo.almalinux.org/almalinux/8.5/isos/aarch64/AlmaLinux-8.5-aarch64-boot.iso"
-  iso_checksum_aarch64  = "file:https://repo.almalinux.org/almalinux/8.5/isos/aarch64/CHECKSUM"
-  iso_url_ppc64le       = "https://repo.almalinux.org/almalinux/8.5/isos/ppc64le/AlmaLinux-8.5-ppc64le-boot.iso"
-  iso_checksum_ppc64le  = "file:https://repo.almalinux.org/almalinux/8.5/isos/ppc64le/CHECKSUM"
-  headless              = true
-  boot_wait             = "10s"
-  cpus                  = 2
-  memory                = 2048
-  post_cpus             = 1
-  post_memory           = 1024
-  http_directory        = "http"
-  ssh_timeout           = "3600s"
-  root_shutdown_command = "/sbin/shutdown -hP now"
-  qemu_binary           = ""
-  firmware_x86_64       = "/usr/share/OVMF/OVMF_CODE.fd"
-  firmware_aarch64      = "/usr/share/AAVMF/AAVMF_CODE.fd"
+  iso_url_8_x86_64       = "https://repo.almalinux.org/almalinux/8.5/isos/x86_64/AlmaLinux-8.5-x86_64-boot.iso"
+  iso_checksum_8_x86_64  = "file:https://repo.almalinux.org/almalinux/8.5/isos/x86_64/CHECKSUM"
+  iso_url_8_aarch64      = "https://repo.almalinux.org/almalinux/8.5/isos/aarch64/AlmaLinux-8.5-aarch64-boot.iso"
+  iso_checksum_8_aarch64 = "file:https://repo.almalinux.org/almalinux/8.5/isos/aarch64/CHECKSUM"
+  iso_url_8_ppc64le      = "https://repo.almalinux.org/almalinux/8.5/isos/ppc64le/AlmaLinux-8.5-ppc64le-boot.iso"
+  iso_checksum_8_ppc64le = "file:https://repo.almalinux.org/almalinux/8.5/isos/ppc64le/CHECKSUM"
+  iso_url_9_x86_64       = "https://repo.almalinux.org/almalinux/9.0-beta/isos/x86_64/AlmaLinux-9.0-beta-1-x86_64-boot.iso"
+  iso_checksum_9_x86_64  = "file:https://repo.almalinux.org/almalinux/9.0-beta/isos/x86_64/CHECKSUM"
+  iso_url_9_aarch64      = "https://repo.almalinux.org/almalinux/9.0-beta/isos/aarch64/AlmaLinux-9.0-beta-1-aarch64-boot.iso"
+  iso_checksum_9_aarch64 = "file:https://repo.almalinux.org/almalinux/9.0-beta/isos/aarch64/CHECKSUM"
+  iso_url_9_ppc64le      = "https://repo.almalinux.org/almalinux/9.0-beta/isos/ppc64le/AlmaLinux-9.0-beta-1-ppc64le-boot.iso"
+  iso_checksum_9_ppc64le = "file:https://repo.almalinux.org/almalinux/9.0-beta/isos/ppc64le/CHECKSUM"
+  headless               = true
+  boot_wait              = "10s"
+  cpus                   = 2
+  memory                 = 2048
+  post_cpus              = 1
+  post_memory            = 1024
+  http_directory         = "http"
+  ssh_timeout            = "3600s"
+  root_shutdown_command  = "/sbin/shutdown -hP now"
+  qemu_binary            = ""
+  firmware_x86_64        = "/usr/share/OVMF/OVMF_CODE.fd"
+  firmware_aarch64       = "/usr/share/AAVMF/AAVMF_CODE.fd"
   //
   // AWS specific variables
   //
-  aws_boot_command = [
+  aws_boot_command_8 = [
     "<tab> inst.text net.ifnames=0 inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-8.aws.ks<enter><wait>"
   ]
   aws_disk_size               = 10240
@@ -53,33 +59,61 @@ variables {
   //
   // Generic Cloud (OpenStack) variables
   //
-  gencloud_boot_command_x86_64 = [
+  gencloud_boot_command_8_x86_64 = [
     "<tab> inst.text net.ifnames=0 inst.gpt inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-8.gencloud-x86_64.ks<enter><wait>"
   ]
-  gencloud_boot_command_x86_64_uefi = [
+  gencloud_boot_command_8_x86_64_uefi = [
     "c<wait>",
-    "linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=AlmaLinux-8-5-x86_64-dvd ro",
+    "linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=AlmaLinux-8-5-x86_64-dvd ro ",
     "inst.text biosdevname=0 net.ifnames=0 ",
     "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-8.gencloud-x86_64.ks<enter>",
     "initrdefi /images/pxeboot/initrd.img<enter>",
     "boot<enter><wait>"
   ]
-  gencloud_boot_command_aarch64 = [
+  gencloud_boot_command_8_aarch64 = [
     "c<wait>",
-    "linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=AlmaLinux-8-5-aarch64-dvd ro",
+    "linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=AlmaLinux-8-5-aarch64-dvd ro ",
     "inst.text biosdevname=0 net.ifnames=0 ",
     "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-8.gencloud-aarch64.ks<enter>",
     "initrd /images/pxeboot/initrd.img<enter>",
     "boot<enter><wait>"
   ]
-  gencloud_boot_command_ppc64le = [
+  gencloud_boot_command_8_ppc64le = [
     "c<wait>",
-    "linux /ppc/ppc64/vmlinuz inst.stage2=hd:LABEL=AlmaLinux-8-5-ppc64le-dvd ro",
+    "linux /ppc/ppc64/vmlinuz inst.stage2=hd:LABEL=AlmaLinux-8-5-ppc64le-dvd ro ",
     "inst.text biosdevname=0 net.ifnames=0 ",
     "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-8.gencloud-ppc64le.ks<enter>",
     "initrd /ppc/ppc64/initrd.img<enter>",
     "boot<enter><wait>"
   ]
+  gencloud_boot_command_9_x86_64_bios = [
+    "<tab> inst.text biosdevname=0 net.ifnames=0 inst.gpt inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-9.gencloud-x86_64-bios.ks<enter><wait>"
+  ]
+  gencloud_boot_command_9_x86_64 = [
+    "c<wait>",
+    "linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=AlmaLinux-9-0-beta-1-x86_64-dvd ro ",
+    "inst.text biosdevname=0 net.ifnames=0 ",
+    "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-9.gencloud-x86_64.ks<enter>",
+    "initrdefi /images/pxeboot/initrd.img<enter>",
+    "boot<enter><wait>"
+  ]
+  gencloud_boot_command_9_aarch64 = [
+    "c<wait>",
+    "linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=AlmaLinux-9-0-beta-1-aarch64-dvd ro ",
+    "inst.text biosdevname=0 net.ifnames=0 ",
+    "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-9.gencloud-aarch64.ks<enter>",
+    "initrd /images/pxeboot/initrd.img<enter>",
+    "boot<enter><wait>"
+  ]
+  gencloud_boot_command_9_ppc64le = [
+    "c<wait>",
+    "linux /ppc/ppc64/vmlinuz inst.stage2=hd:LABEL=AlmaLinux-9-0-beta-1-ppc64le-dvd ro ",
+    "inst.text biosdevname=0 net.ifnames=0 ",
+    "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-9.gencloud-ppc64le.ks<enter>",
+    "initrd /ppc/ppc64/initrd.img<enter>",
+    "boot<enter><wait>"
+  ]
+
   gencloud_disk_size         = "10G"
   gencloud_ssh_username      = "root"
   gencloud_ssh_password      = "almalinux"
@@ -91,10 +125,10 @@ variables {
   //
   // Vagrant specific variables
   //
-  vagrant_boot_command = [
+  vagrant_boot_command_8_x86_64 = [
     "<tab> inst.text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-8.vagrant.ks<enter><wait>"
   ]
-  vagrant_efi_boot_command = [
+  vagrant_efi_boot_command_8_x86_64 = [
     "e<down><down><end><bs><bs><bs><bs><bs>inst.text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-8.vagrant.ks<leftCtrlOn>x<leftCtrlOff>"
   ]
   vagrant_disk_size        = 20000
@@ -104,10 +138,10 @@ variables {
   //
   // OpenNebula variables
   //
-  opennebula_boot_command_x86_64 = [
+  opennebula_boot_command_8_x86_64 = [
     "<tab> inst.text net.ifnames=0 inst.gpt inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-8.opennebula-x86_64.ks<enter><wait>"
   ]
-  opennebula_boot_command_aarch64 = [
+  opennebula_boot_command_8_aarch64 = [
     "c<wait>",
     "linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=AlmaLinux-8-5-aarch64-dvd ro",
     "inst.text biosdevname=0 net.ifnames=0 ",

--- a/versions.pkr.hcl
+++ b/versions.pkr.hcl
@@ -2,7 +2,7 @@ packer {
   required_version = ">= 1.7.0"
   required_plugins {
     qemu = {
-      version = "1.0.2"
+      version = ">= 1.0.3"
       source  = "github.com/hashicorp/qemu"
     }
     virtualbox = {


### PR DESCRIPTION
* Add AlmaLinux OS 9 x86_64-v2(BIOS+UEFI), x86_64-v2(BIOS) and aarch64
  GenericCloud Image support
* Use the major number of the OS version on ISO URLs, checksums and boot
  command
* Change minimal Packer QEMU plugin version from 1.0.2 to 1.0.3 to use
  the use_pflash option for each type of the architecture (x86_64:
  -pflash, aarch64: -bios)
* Remove the random seed as recommended by systemd-random-seed.service
  documentation
* Add tuned and tcpdump packages for being compatible upstream generic
  cloud image
* Set virtual-guest as the default profile for tuned
* Configure NetworkManager default DHCP timeout to 300 seconds

Signed-off-by: Elkhan Mammadli <elkhan.mammadli@protonmail.com>