### PR TITLE
Add OpenNebula for 9 and various enhancements

### DIFF
--- a/almalinux-9-opennebula.pkr.hcl
+++ b/almalinux-9-opennebula.pkr.hcl
@@ -1,0 +1,121 @@
+/*
+ * AlmaLinux OS 9 Packer template for building OpenNebula images.
+ */
+
+source "qemu" "almalinux-9-opennebula-bios-x86_64" {
+  iso_url            = var.iso_url_9_x86_64
+  iso_checksum       = var.iso_checksum_9_x86_64
+  shutdown_command   = var.root_shutdown_command
+  accelerator        = "kvm"
+  http_directory     = var.http_directory
+  ssh_username       = var.gencloud_ssh_username
+  ssh_password       = var.gencloud_ssh_password
+  ssh_timeout        = var.ssh_timeout
+  cpus               = var.cpus
+  disk_interface     = "virtio-scsi"
+  disk_size          = var.gencloud_disk_size
+  disk_cache         = "unsafe"
+  disk_discard       = "unmap"
+  disk_detect_zeroes = "unmap"
+  disk_compression   = true
+  format             = "qcow2"
+  headless           = var.headless
+  machine_type       = "q35"
+  memory             = var.memory
+  net_device         = "virtio-net"
+  qemu_binary        = var.qemu_binary
+  vm_name            = "AlmaLinux-9-OpenNebula-BIOS-9.0-${formatdate("YYYYMMDD", timestamp())}.x86_64.qcow2"
+  boot_wait          = var.boot_wait
+  boot_command       = var.gencloud_boot_command_9_x86_64_bios
+  qemuargs = [
+    ["-cpu", "host"]
+  ]
+}
+
+
+source "qemu" "almalinux-9-opennebula-x86_64" {
+  iso_url            = var.iso_url_9_x86_64
+  iso_checksum       = var.iso_checksum_9_x86_64
+  shutdown_command   = var.root_shutdown_command
+  accelerator        = "kvm"
+  http_directory     = var.http_directory
+  ssh_username       = var.gencloud_ssh_username
+  ssh_password       = var.gencloud_ssh_password
+  ssh_timeout        = var.ssh_timeout
+  cpus               = var.cpus
+  firmware           = var.firmware_x86_64
+  disk_interface     = "virtio-scsi"
+  disk_size          = var.gencloud_disk_size
+  disk_cache         = "unsafe"
+  disk_discard       = "unmap"
+  disk_detect_zeroes = "unmap"
+  disk_compression   = true
+  format             = "qcow2"
+  headless           = var.headless
+  machine_type       = "q35"
+  memory             = var.memory
+  net_device         = "virtio-net"
+  qemu_binary        = var.qemu_binary
+  vm_name            = "AlmaLinux-9-OpenNebula-9.0-${formatdate("YYYYMMDD", timestamp())}.x86_64.qcow2"
+  boot_wait          = var.boot_wait
+  boot_command       = var.gencloud_boot_command_9_x86_64
+  qemuargs = [
+    ["-cpu", "host"]
+  ]
+}
+
+
+source "qemu" "almalinux-9-opennebula-aarch64" {
+  iso_url            = var.iso_url_9_aarch64
+  iso_checksum       = var.iso_checksum_9_aarch64
+  shutdown_command   = var.root_shutdown_command
+  accelerator        = "kvm"
+  http_directory     = var.http_directory
+  ssh_username       = var.gencloud_ssh_username
+  ssh_password       = var.gencloud_ssh_password
+  ssh_timeout        = var.ssh_timeout
+  cpus               = var.cpus
+  firmware           = var.firmware_aarch64
+  use_pflash         = false
+  disk_interface     = "virtio-scsi"
+  disk_size          = var.gencloud_disk_size
+  disk_cache         = "unsafe"
+  disk_discard       = "unmap"
+  disk_detect_zeroes = "unmap"
+  disk_compression   = true
+  format             = "qcow2"
+  headless           = var.headless
+  machine_type       = "virt,gic-version=max"
+  memory             = var.memory
+  net_device         = "virtio-net"
+  qemu_binary        = var.qemu_binary
+  vm_name            = "AlmaLinux-9-OpenNebula-9.0-${formatdate("YYYYMMDD", timestamp())}.aarch64.qcow2"
+  boot_wait          = var.boot_wait
+  boot_command       = var.gencloud_boot_command_9_aarch64
+  qemuargs = [
+    ["-cpu", "max"],
+    ["-boot", "strict=on"],
+    ["-monitor", "none"]
+  ]
+}
+
+
+build {
+  sources = [
+    "qemu.almalinux-9-opennebula-bios-x86_64",
+    "qemu.almalinux-9-opennebula-x86_64",
+    "qemu.almalinux-9-opennebula-aarch64"
+  ]
+
+  provisioner "ansible" {
+    playbook_file    = "./ansible/opennebula.yml"
+    galaxy_file      = "./ansible/requirements.yml"
+    roles_path       = "./ansible/roles"
+    collections_path = "./ansible/collections"
+    ansible_env_vars = [
+      "ANSIBLE_PIPELINING=True",
+      "ANSIBLE_REMOTE_TEMP=/tmp",
+      "ANSIBLE_SSH_ARGS='-o ControlMaster=no -o ControlPersist=180s -o ServerAliveInterval=120s -o TCPKeepAlive=yes'"
+    ]
+  }
+}

--- a/ansible/roles/opennebula_guest/tasks/main.yml
+++ b/ansible/roles/opennebula_guest/tasks/main.yml
@@ -9,13 +9,20 @@
     name: one-context
     state: present
 
-- name: Enable one-context and network services
+- name: Enable one-context and network services for 8
   service:
     name: "{{ item }}"
     enabled: true
   loop:
     - one-context
     - network
+  when: ansible_facts['distribution_major_version'] == '8'
+
+- name: Enable one-context services for 9
+  service:
+    name: one-context
+    enabled: true
+  when: ansible_facts['distribution_major_version'] == '9'
 
 - name: Install disk resize dependencies
   package:
@@ -24,5 +31,5 @@
       - parted
     state: latest
 
-- name: Update initramfs
-  command: dracut -f
+- name: Regenerate the initramfs
+  command: dracut -f --regenerate-all

--- a/http/almalinux-9.gencloud-x86_64-bios.ks
+++ b/http/almalinux-9.gencloud-x86_64-bios.ks
@@ -31,13 +31,18 @@ reboot --eject
 
 %packages --inst-langs=en
 @core
+dracut-config-generic
+usermode
 -biosdevname
--open-vm-tools
--plymouth
 -dnf-plugin-spacewalk
--rhn*
+-dracut-config-rescue
 -iprutils
 -iwl*-firmware
+-langpacks-*
+-mdadm
+-open-vm-tools
+-plymouth
+-rhn*
 %end
 
 

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -141,7 +141,7 @@ variables {
   ]
   vagrant_efi_boot_command_9_x86_64 = [
     "c<wait>",
-    "linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=AlmaLinux-9-0-beta-1-x86_64-dvd ro ",
+    "linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=AlmaLinux-9-0-x86_64-dvd ro ",
     "inst.text biosdevname=0 net.ifnames=0 ",
     "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-9.vagrant.ks<enter>",
     "initrdefi /images/pxeboot/initrd.img<enter>",
@@ -159,7 +159,7 @@ variables {
   ]
   opennebula_boot_command_8_aarch64 = [
     "c<wait>",
-    "linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=AlmaLinux-8-6-aarch64-dvd ro",
+    "linux /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=AlmaLinux-8-6-aarch64-dvd ro ",
     "inst.text biosdevname=0 net.ifnames=0 ",
     "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-8.opennebula-aarch64.ks<enter>",
     "initrd /images/pxeboot/initrd.img<enter>",


### PR DESCRIPTION
* Add AlmaLinux OS 9 OpenNebula BIOS+UEFI, BIOS x86_64
and AArch64 images
* Update vagrant uefi boot command from 9.0 beta 1 to 9.0
* Enable only one-context service for AlmaLinux 9 OS since
* EL 9 does not contain the legacy network scripts
* Use same package list on Generic Cloud BIOS and
BIOS+UEFI kickstart files

Signed-off-by: Elkhan Mammadli <elkhan.mammadli@protonmail.com>