### PR TITLE
Add more cleanup steps and some updates

### DIFF
--- a/almalinux-8-aws-stage2.pkr.hcl
+++ b/almalinux-8-aws-stage2.pkr.hcl
@@ -42,6 +42,7 @@ build {
     "sources.amazon-chroot.almalinux-8-aws-stage2"
   ]
   provisioner "ansible" {
+    galaxy_file    = "./ansible/requirements.yml"
     inventory_file = "./ansible/aws-ami-stage2.inventory"
     playbook_file  = "./ansible/aws-ami-stage2.yml"
     extra_arguments = [

--- a/ansible/roles/cleanup_vm/tasks/main.yml
+++ b/ansible/roles/cleanup_vm/tasks/main.yml
@@ -67,6 +67,9 @@
     - /var/log/qemu-ga
     - /var/log/tuned
     - /var/lib/cloud
+    - /etc/hostname
+    - /etc/machine-info
+    - /var/lib/systemd/credential.secret
 
 - name: Find log files.
   find:

--- a/build-tools-on-ec2-userdata.yml
+++ b/build-tools-on-ec2-userdata.yml
@@ -17,12 +17,11 @@ yum_repos:
     # any repository configuration options (see man yum.conf)
 
 packages:
-  - epel-release
+  - ansible-core
   - packer
   - tmux
   - git-core
 
 runcmd:
-  - [ dnf, -y, install, ansible ]
   - [ ln, -s, "/usr/bin/packer", "/usr/bin/packer.io" ]
   - [ sudo, -u, ec2-user, git, clone, "https://github.com/AlmaLinux/cloud-images.git", "/home/ec2-user/cloud-images" ]


### PR DESCRIPTION
* Add extra cleanup steps for cleanup_vm ansible role
from https://systemd.io/BUILDING_IMAGES
* Switch from ansible 2.9 (EPEL8) to ansible-core (Appstream) for the
second build stage of AlmaLinux OS 8 x86_64 Amazon Machine Images

Signed-off-by: Elkhan Mammadli <elkhan.mammadli@protonmail.com>