### PR TITLE
Fix and update for 8(AArch64) and 9(All) AMIs

### DIFF
--- a/almalinux-8-aws-aarch64.pkr.hcl
+++ b/almalinux-8-aws-aarch64.pkr.hcl
@@ -42,13 +42,12 @@ build {
     "sources.amazon-ebssurrogate.almalinux-8-aws-aarch64"
   ]
   provisioner "shell" {
-    inline = ["sudo dnf -y install python39 python39-pip python39-{wheel,setuptools} && sudo python3 -m pip install ansible"]
+    inline = ["sudo dnf -y install ansible-core"]
   }
   provisioner "ansible-local" {
-    playbook_dir   = "./ansible"
-    playbook_file  = "./ansible/aws-ami-aarch64.yml"
-    galaxy_file    = "./ansible/requirements.yml"
-    galaxy_command = "ansible-galaxy collection install -r"
+    playbook_dir  = "./ansible"
+    playbook_file = "./ansible/aws-ami-aarch64.yml"
+    galaxy_file   = "./ansible/requirements.yml"
   }
 
 }

--- a/almalinux-9-ami.pkr.hcl
+++ b/almalinux-9-ami.pkr.hcl
@@ -78,22 +78,20 @@ build {
     "sources.amazon-ebssurrogate.almalinux-9-ami-aarch64"
   ]
   provisioner "shell" {
-    inline = ["sudo dnf config-manager --set-enabled crb && sudo dnf -y install dosfstools python3-wheel python3-pip && sudo python3 -m pip install ansible"]
+    inline = ["sudo dnf -y install ansible-core dosfstools"]
   }
   provisioner "ansible-local" {
-    playbook_dir   = "./ansible"
-    playbook_file  = "./ansible/ami-9-x86_64.yaml"
-    galaxy_file    = "./ansible/requirements.yml"
-    galaxy_command = "ansible-galaxy collection install -r"
+    playbook_dir  = "./ansible"
+    playbook_file = "./ansible/ami-9-x86_64.yaml"
+    galaxy_file   = "./ansible/requirements.yml"
     only = [
       "amazon-ebssurrogate.almalinux-9-ami-x86_64"
     ]
   }
   provisioner "ansible-local" {
-    playbook_dir   = "./ansible"
-    playbook_file  = "./ansible/ami-9-aarch64.yaml"
-    galaxy_file    = "./ansible/requirements.yml"
-    galaxy_command = "ansible-galaxy collection install -r"
+    playbook_dir  = "./ansible"
+    playbook_file = "./ansible/ami-9-aarch64.yaml"
+    galaxy_file   = "./ansible/requirements.yml"
     only = [
       "amazon-ebssurrogate.almalinux-9-ami-aarch64"
     ]

--- a/versions.pkr.hcl
+++ b/versions.pkr.hcl
@@ -22,7 +22,7 @@ packer {
       source  = "github.com/hashicorp/parallels"
     }
     ansible = {
-      version = ">= 1.0.0"
+      version = ">= 1.0.3"
       source  = "github.com/hashicorp/ansible"
     }
     amazon = {


### PR DESCRIPTION
Since Packer's ansible plugin got support for collections
to ansible-local provisioner on version 1.0.3

* No need to use the galaxy_command option to install
collections manually. This option doesn't work with the new collection
support adding "`install -r install -r`" to the collection installer
command:
`ansible-galaxy collection install -r install -r requirements.yml \
    -p galaxy_roles/`
* Set minimum required packer ansible plugin from 1.0.0 to 1.0.3
* Switch from ansible pip package to ansible-core from AppStream

Signed-off-by: Elkhan Mammadli <elkhan.mammadli@protonmail.com>