### PR TITLE
Change AlmaLinux OS 8 OpenNebula image output name

### DIFF
--- a/almalinux-8-opennebula.pkr.hcl
+++ b/almalinux-8-opennebula.pkr.hcl
@@ -23,7 +23,7 @@ source "qemu" "almalinux-8-opennebula-x86_64" {
   memory             = var.memory
   net_device         = "virtio-net"
   qemu_binary        = var.qemu_binary
-  vm_name            = "almalinux-8-OpenNebula-8.6.x86_64.qcow2"
+  vm_name            = "AlmaLinux-8-OpenNebula-8.6-${formatdate("YYYYMMDD", timestamp())}.x86_64.qcow2"
   boot_wait          = var.boot_wait
   boot_command       = var.opennebula_boot_command_8_x86_64
 }
@@ -53,7 +53,7 @@ source "qemu" "almalinux-8-opennebula-aarch64" {
   memory             = var.memory
   net_device         = "virtio-net"
   qemu_binary        = var.qemu_binary
-  vm_name            = "almalinux-8-OpenNebula-8.6.aarch64.qcow2"
+  vm_name            = "AlmaLinux-8-OpenNebula-8.6-${formatdate("YYYYMMDD", timestamp())}.aarch64.qcow2"
   boot_wait          = var.boot_wait
   boot_command       = var.opennebula_boot_command_8_aarch64
   qemuargs = [


### PR DESCRIPTION
Change the name of the AlmaLinux OS 8 OpenNebula output image file
with a timestamp in the "YYYYMMDD" format and adjust
naming scheme with repository one.

Signed-off-by: Elkhan Mammadli <elkhan.mammadli@protonmail.com>