### PR TITLE
Add cPanel and Plesk preinstalled images

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ AlmaLinux OS images for various cloud platforms.
 | Azure Marketplace | `x86_64` | https://wiki.almalinux.org/cloud/Azure.html |
 | Docker Hub | `x86_64` `AArch64` `ppc64le` `s390x` | https://wiki.almalinux.org/containers/docker-images.html |
 | Generic Cloud (OpenStack) | `x86_64` `AArch64` `ppc64le` `s390x` | https://wiki.almalinux.org/cloud/Generic-cloud.html |
+| cPanel Generic Cloud (OpenStack) | `x86_64` | https://wiki.almalinux.org/cloud/cPanel-Generic-cloud.html |
+| Plesk Generic Cloud (OpenStack) | `x86_64` | https://wiki.almalinux.org/cloud/Plesk-Generic-cloud.html |
 | Google Cloud | `x86_64` | https://wiki.almalinux.org/cloud/Google.html |
 | LXC/LXD | `x86_64` `AArch64` `ppc64le` | https://images.linuxcontainers.org |
 | OpenNebula | `x86_64` `AArch64` | https://wiki.almalinux.org/cloud/OpenNebula.html |
@@ -37,6 +39,7 @@ AlmaLinux OS images for various cloud platforms.
 * [x] LXC/LXD support (#8)
 * [x] OpenNebula `x86_64` and `aarch64` support
 * [x] Oracle Cloud Infrastructure `x86_64` and `aarch64` support
+* [x] cPanel and Plesk support
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ AlmaLinux OS images for various cloud platforms.
 | AWS Community AMI | `x86_64` `AArch64` | https://wiki.almalinux.org/cloud/AWS.html |
 | AWS Marketplace AMI | `x86_64` `AArch64` | https://aws.amazon.com/marketplace/seller-profile?id=529d1014-352c-4bed-8b63-6120e4bd3342 |
 | Azure Marketplace | `x86_64` | https://wiki.almalinux.org/cloud/Azure.html |
+| cPanel Generic Cloud (OpenStack) | `x86_64` | https://wiki.almalinux.org/cloud/cPanel-Generic-cloud.html |
 | Docker Hub | `x86_64` `AArch64` `ppc64le` `s390x` | https://wiki.almalinux.org/containers/docker-images.html |
 | Generic Cloud (OpenStack) | `x86_64` `AArch64` `ppc64le` `s390x` | https://wiki.almalinux.org/cloud/Generic-cloud.html |
-| cPanel Generic Cloud (OpenStack) | `x86_64` | https://wiki.almalinux.org/cloud/cPanel-Generic-cloud.html |
-| Plesk Generic Cloud (OpenStack) | `x86_64` | https://wiki.almalinux.org/cloud/Plesk-Generic-cloud.html |
 | Google Cloud | `x86_64` | https://wiki.almalinux.org/cloud/Google.html |
 | LXC/LXD | `x86_64` `AArch64` `ppc64le` | https://images.linuxcontainers.org |
 | OpenNebula | `x86_64` `AArch64` | https://wiki.almalinux.org/cloud/OpenNebula.html |
 | Oracle Cloud Infrastructure | `x86_64` `AArch64` | https://wiki.almalinux.org/cloud/OCI.html |
+| Plesk Generic Cloud (OpenStack) | `x86_64` | https://wiki.almalinux.org/cloud/Plesk-Generic-cloud.html |
 | Quay.io | `x86_64` `AArch64` `ppc64le` `s390x` | https://quay.io/repository/almalinux/almalinux |
 | Vagrant | `virtualbox`(`x86_64`), `libvirt`(`x86_64`), `vmware_desktop`(`x86_64`), `hyperv`(`x86_64`), `parallels`(`x86_64, AArch64`) | https://app.vagrantup.com/almalinux |
 

--- a/almalinux-8-cpanel-gencloud.pkr.hcl
+++ b/almalinux-8-cpanel-gencloud.pkr.hcl
@@ -1,0 +1,79 @@
+/*
+ * AlmaLinux OS 8 Packer template for building Generic Cloud (OpenStack compatible) images.
+ */
+
+source "qemu" "almalinux-8-cpanel-gencloud-x86_64" {
+  iso_url            = var.iso_url_8_x86_64
+  iso_checksum       = var.iso_checksum_8_x86_64
+  shutdown_command   = var.root_shutdown_command
+  accelerator        = "kvm"
+  http_directory     = var.http_directory
+  ssh_username       = var.gencloud_ssh_username
+  ssh_password       = var.gencloud_ssh_password
+  ssh_timeout        = var.ssh_timeout
+  cpus               = var.cpus
+  disk_interface     = "virtio-scsi"
+  disk_size          = var.gencloud_disk_size
+  disk_cache         = "unsafe"
+  disk_discard       = "unmap"
+  disk_detect_zeroes = "unmap"
+  disk_compression   = true
+  format             = "qcow2"
+  headless           = var.headless
+  memory             = var.memory
+  net_device         = "virtio-net"
+  qemu_binary        = var.qemu_binary
+  vm_name            = "AlmaLinux-8-GenericCloud-8.6-with-cPanel-${formatdate("YYYYMMDD", timestamp())}.x86_64.qcow2"
+  boot_wait          = var.boot_wait
+  boot_command       = var.gencloud_boot_command_8_x86_64
+}
+
+source "qemu" "almalinux-8-cpanel-gencloud-uefi-x86_64" {
+  iso_url            = var.iso_url_8_x86_64
+  iso_checksum       = var.iso_checksum_8_x86_64
+  shutdown_command   = var.root_shutdown_command
+  accelerator        = "kvm"
+  http_directory     = var.http_directory
+  ssh_username       = var.gencloud_ssh_username
+  ssh_password       = var.gencloud_ssh_password
+  ssh_timeout        = var.ssh_timeout
+  cpus               = var.cpus
+  firmware           = var.firmware_x86_64
+  use_pflash         = true
+  disk_interface     = "virtio-scsi"
+  disk_size          = var.gencloud_disk_size
+  disk_cache         = "unsafe"
+  disk_discard       = "unmap"
+  disk_detect_zeroes = "unmap"
+  disk_compression   = true
+  format             = "qcow2"
+  headless           = var.headless
+  memory             = var.memory
+  net_device         = "virtio-net"
+  qemu_binary        = var.qemu_binary
+  vm_name            = "AlmaLinux-8-GenericCloud-UEFI-8.6-with-cPanel-${formatdate("YYYYMMDD", timestamp())}.x86_64.qcow2"
+  boot_wait          = var.boot_wait
+  boot_command       = var.gencloud_boot_command_8_x86_64_uefi
+}
+
+
+
+
+build {
+  sources = [
+    "qemu.almalinux-8-cpanel-gencloud-x86_64",
+    "qemu.almalinux-8-cpanel-gencloud-uefi-x86_64",
+  ]
+
+  provisioner "ansible" {
+    playbook_file    = "./ansible/cpanel-gencloud.yml"
+    galaxy_file      = "./ansible/requirements.yml"
+    roles_path       = "./ansible/roles"
+    collections_path = "./ansible/collections"
+    ansible_env_vars = [
+      "ANSIBLE_PIPELINING=True",
+      "ANSIBLE_REMOTE_TEMP=/tmp",
+      "ANSIBLE_SSH_ARGS='-o ControlMaster=no -o ControlPersist=180s -o ServerAliveInterval=120s -o TCPKeepAlive=yes'"
+    ]
+  }
+}

--- a/almalinux-8-plesk-gencloud.pkr.hcl
+++ b/almalinux-8-plesk-gencloud.pkr.hcl
@@ -1,0 +1,79 @@
+/*
+ * AlmaLinux OS 8 Packer template for building Generic Cloud (OpenStack compatible) images.
+ */
+
+source "qemu" "almalinux-8-plesk-gencloud-x86_64" {
+  iso_url            = var.iso_url_8_x86_64
+  iso_checksum       = var.iso_checksum_8_x86_64
+  shutdown_command   = var.root_shutdown_command
+  accelerator        = "kvm"
+  http_directory     = var.http_directory
+  ssh_username       = var.gencloud_ssh_username
+  ssh_password       = var.gencloud_ssh_password
+  ssh_timeout        = var.ssh_timeout
+  cpus               = var.cpus
+  disk_interface     = "virtio-scsi"
+  disk_size          = var.gencloud_disk_size
+  disk_cache         = "unsafe"
+  disk_discard       = "unmap"
+  disk_detect_zeroes = "unmap"
+  disk_compression   = true
+  format             = "qcow2"
+  headless           = var.headless
+  memory             = var.memory
+  net_device         = "virtio-net"
+  qemu_binary        = var.qemu_binary
+  vm_name            = "AlmaLinux-8-GenericCloud-8.6-with-Plesk-${formatdate("YYYYMMDD", timestamp())}.x86_64.qcow2"
+  boot_wait          = var.boot_wait
+  boot_command       = var.gencloud_boot_command_8_x86_64
+}
+
+source "qemu" "almalinux-8-plesk-gencloud-uefi-x86_64" {
+  iso_url            = var.iso_url_8_x86_64
+  iso_checksum       = var.iso_checksum_8_x86_64
+  shutdown_command   = var.root_shutdown_command
+  accelerator        = "kvm"
+  http_directory     = var.http_directory
+  ssh_username       = var.gencloud_ssh_username
+  ssh_password       = var.gencloud_ssh_password
+  ssh_timeout        = var.ssh_timeout
+  cpus               = var.cpus
+  firmware           = var.firmware_x86_64
+  use_pflash         = true
+  disk_interface     = "virtio-scsi"
+  disk_size          = var.gencloud_disk_size
+  disk_cache         = "unsafe"
+  disk_discard       = "unmap"
+  disk_detect_zeroes = "unmap"
+  disk_compression   = true
+  format             = "qcow2"
+  headless           = var.headless
+  memory             = var.memory
+  net_device         = "virtio-net"
+  qemu_binary        = var.qemu_binary
+  vm_name            = "AlmaLinux-8-GenericCloud-UEFI-8.6-with-Plesk-${formatdate("YYYYMMDD", timestamp())}.x86_64.qcow2"
+  boot_wait          = var.boot_wait
+  boot_command       = var.gencloud_boot_command_8_x86_64_uefi
+}
+
+
+
+
+build {
+  sources = [
+    "qemu.almalinux-8-plesk-gencloud-x86_64",
+    "qemu.almalinux-8-plesk-gencloud-uefi-x86_64",
+  ]
+
+  provisioner "ansible" {
+    playbook_file    = "./ansible/plesk-gencloud.yml"
+    galaxy_file      = "./ansible/requirements.yml"
+    roles_path       = "./ansible/roles"
+    collections_path = "./ansible/collections"
+    ansible_env_vars = [
+      "ANSIBLE_PIPELINING=True",
+      "ANSIBLE_REMOTE_TEMP=/tmp",
+      "ANSIBLE_SSH_ARGS='-o ControlMaster=no -o ControlPersist=180s -o ServerAliveInterval=120s -o TCPKeepAlive=yes'"
+    ]
+  }
+}

--- a/ansible/cpanel-gencloud.yml
+++ b/ansible/cpanel-gencloud.yml
@@ -1,0 +1,10 @@
+# An Ansible playbook that configures a cPanel Generic Cloud (OpenStack) image
+---
+- name: AlmaLinux cPanel Generic Cloud
+  hosts: default
+  become: true
+  ansible.builtin.shell: yum update -y && csf -x && systemctl stop firewalld.service && systemctl disable firewalld.service && setenforce 0 && yum install perl curl wget -y && hostnamectl set-hostname cpanel-build.almalinux.org && service NetworkManager start && chkconfig NetworkManager on && cd /home && curl -o latest -L https://securedownloads.cpanel.net/latest && sh latest
+
+  roles:
+    - gencloud_guest
+    - cleanup_vm

--- a/ansible/plesk-gencloud.yml
+++ b/ansible/plesk-gencloud.yml
@@ -1,0 +1,10 @@
+# An Ansible playbook that configures a Plesk Generic Cloud (OpenStack) image
+---
+- name: AlmaLinux Plesk Generic Cloud
+  hosts: default
+  become: true
+  ansible.builtin.shell: yum update -y && csf -x && systemctl stop firewalld.service && systemctl disable firewalld.service && setenforce 0 && yum install perl curl wget -y && hostnamectl set-hostname plesk-build.almalinux.org && service NetworkManager start && chkconfig NetworkManager on && wget https://autoinstall.plesk.com/plesk-installer && sudo chmod +x plesk-installer && sudo ./plesk-installer
+
+  roles:
+    - gencloud_guest
+    - cleanup_vm


### PR DESCRIPTION
See #49.
This PR will add cPanel and Plesk templates to build cPanel and Plesk images for AlmaLinux 8.6. AlmaLinux 9.0 does not support cPanel and Plesk yet.