### PR TITLE
Add DigitalOcean images for AlmaLinux 9

### DIFF
--- a/almalinux-9-digitalocean.pkr.hcl
+++ b/almalinux-9-digitalocean.pkr.hcl
@@ -1,10 +1,10 @@
 /*
- * AlmaLinux OS 8 Packer template for building DigitalOcean images.
+ * AlmaLinux OS 9 Packer template for building DigitalOcean images.
  */
 
-source "qemu" "almalinux-8-digitalocean-x86_64" {
-  iso_url            = var.iso_url_8_x86_64
-  iso_checksum       = var.iso_checksum_8_x86_64
+source "qemu" "almalinux-9-digitalocean-x86_64" {
+  iso_url            = var.iso_url_9_x86_64
+  iso_checksum       = var.iso_checksum_9_x86_64
   shutdown_command   = var.root_shutdown_command
   accelerator        = "kvm"
   http_directory     = var.http_directory
@@ -20,17 +20,21 @@ source "qemu" "almalinux-8-digitalocean-x86_64" {
   disk_compression   = true
   format             = "qcow2"
   headless           = var.headless
+  machine_type       = "q35"
   memory             = var.memory
   net_device         = "virtio-net"
   qemu_binary        = var.qemu_binary
-  vm_name            = "almalinux-8-DigitalOcean-8.6.x86_64.qcow2"
+  vm_name            = "almalinux-9-DigitalOcean-9.0.x86_64.qcow2"
   boot_wait          = var.boot_wait
-  boot_command       = var.gencloud_boot_command_8_x86_64
+  boot_command       = var.gencloud_boot_command_9_x86_64_bios
+  qemuargs = [
+    ["-cpu", "host"]
+  ]
 }
 
 
 build {
-  sources = ["qemu.almalinux-8-digitalocean-x86_64"]
+  sources = ["qemu.almalinux-9-digitalocean-x86_64"]
 
   provisioner "ansible" {
     playbook_file    = "./ansible/digitalocean.yml"
@@ -56,7 +60,7 @@ build {
     spaces_secret      = var.do_spaces_secret
     spaces_region      = var.do_spaces_region
     space_name         = var.do_space_name
-    image_name         = var.do_image_name_8
+    image_name         = var.do_image_name_9
     image_regions      = var.do_image_regions
     image_description  = var.do_image_description
     image_distribution = var.do_image_distribution

--- a/ansible/roles/digitalocean_guest/tasks/main.yml
+++ b/ansible/roles/digitalocean_guest/tasks/main.yml
@@ -24,6 +24,8 @@
       - nfs-utils
       - rsync
       - tar
+      - tuned
+      - tcpdump
 
 - name: Find persistent-net.rules
   find:
@@ -67,25 +69,47 @@
     regexp: '^#?NAutoVTs=\d+'
     replace: 'NAutoVTs=0'
 
-- name: Configure dhclient
-  lineinfile:
-    path: /etc/dhcp/dhclient.conf
-    line: "{{ item }}"
-  with_items:
-    - 'timeout 300;'
-    - 'retry 60;'
+- name: Configure NetworkManager default DHCP timeout
+  community.general.ini_file:
+    path: /etc/NetworkManager/conf.d/dhcp.conf
+    section: connection
+    option: ipv4.dhcp-timeout
+    value: 300
+    owner: root
+    group: root
+    mode: 0644
+    seuser: system_u
+
 
 - name: Set infra yum variable to 'genclo'
   replace:
     path: /etc/yum/vars/infra
     regexp: '^(.*?)$'
     replace: 'genclo'
+  when: ansible_facts['distribution_major_version'] == '8'
 
 - name: Set default kernel package type to kernel
   replace:
     path: /etc/sysconfig/kernel
     regexp: '^(DEFAULTKERNEL=).*$'
     replace: '\1kernel'
+
+# TODO: Delete it after this patch backported or upstream cloud-init rebased on 22.2: https://github.com/canonical/cloud-init/pull/1355
+- name: Workaround for cloud-init locale bug
+  lineinfile:
+    path: /etc/cloud/cloud.cfg
+    line: 'locale: C.UTF-8'
+    state: present
+  when: ansible_facts['distribution_major_version'] == '9'
+
+- name: Set virtual-guest as default profile for tuned
+  lineinfile:
+    path: /etc/tuned/active_profile
+    line: virtual-guest
+    create: yes
+
+- name: Regenerate the initramfs
+  command: dracut -f --regenerate-all
 
 - name: Add almalinux user to /etc/sudoers
   lineinfile:

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -56,7 +56,8 @@ variables {
   do_spaces_secret      = env("DIGITALOCEAN_SPACES_SECRET_KEY")
   do_spaces_region      = "nyc3"
   do_space_name         = env("DIGITALOCEAN_SPACE_NAME")
-  do_image_name         = "AlmaLinux OS 8.6.{{isotime \"20060102\"}} x86_64"
+  do_image_name_8       = "AlmaLinux OS 8.6.{{isotime \"20060102\"}} x86_64"
+  do_image_name_9       = "AlmaLinux OS 9.0.{{isotime \"20060102\"}} x86_64"
   do_image_regions      = ["nyc3"]
   do_image_description  = "Official AlmaLinux OS Image"
   do_image_distribution = "AlmaLinux OS"

--- a/vm-scripts/digitalocean/99-img-check.sh
+++ b/vm-scripts/digitalocean/99-img-check.sh
@@ -562,6 +562,8 @@ elif [[ $OS == "AlmaLinux" ]]; then
         ost=1
     if [[ $VER =~ 8.[3-9] ]]; then
         osv=1
+    elif [[ $VER =~ 9.0 ]]; then
+        osv=1
     else
         osv=2
     fi


### PR DESCRIPTION
This essentially applies the relevant changes from:

- 2a617acda1f0bc4c2e9941d01c59502c7d1d8df9
- 3afd0c736f78b929e40e1a32ab9271b1eeca978b

It's undergone basic smoke testing with a newly DigitalOcean droplet, to ensure that fundamental tasks (SSH access, networking) work properly.

Fixes #109.

<hr>

Yes I know @LKHN had self-assigned the issue, but I was already in too deep :sweat_smile: 