### PR TITLE
Clean-up the Cloud-init leftovers for 8 AMI

### DIFF
--- a/ansible/aws-ami-stage2.yml
+++ b/ansible/aws-ami-stage2.yml
@@ -107,6 +107,22 @@
       loop: "{{ log_files.files }}"
 
 
+    - name: Find sudoers files created by AWS VM Import/Export
+      find:
+        file_type: file
+        paths:
+          - /etc/sudoers.d/
+        patterns: '*'
+      register: sudoers_files
+
+
+    - name: Remove found sudoers files
+      file:
+        path: "{{ item.path }}"
+        state: absent
+      loop: "{{ sudoers_files.files }}"
+
+
     - name: Truncate files
       command: "truncate -s 0 {{ item }}"
       loop:


### PR DESCRIPTION
On the second stage of the AlmaLinux OS 8 AMI building the AWS VM Import/Export creates
"/etc/sudoers.d/90-cloud-init-users" for "ec2-user":

ec2-user ALL=(ALL) NOPASSWD:ALL

ec2-user ALL=(ALL) NOPASSWD:ALL

Make sure no sudoers file present from the second stage

Signed-off-by: Elkhan Mammadli <elkhan.mammadli@protonmail.com>