### PR TITLE
Update source AMIs to 8.7 and 9.1

### DIFF
--- a/almalinux-8-aws-aarch64.pkr.hcl
+++ b/almalinux-8-aws-aarch64.pkr.hcl
@@ -6,7 +6,7 @@ source "amazon-ebssurrogate" "almalinux-8-aws-aarch64" {
   region                  = "us-east-1"
   ssh_username            = "ec2-user"
   instance_type           = "t4g.micro"
-  source_ami              = "ami-0543832c8973af485"
+  source_ami              = "ami-02c9a8bba92028114"
   ami_name                = var.aws_ami_name_aarch64_8
   ami_description         = var.aws_ami_description_aarch64_8
   ami_architecture        = "arm64"

--- a/almalinux-9-ami.pkr.hcl
+++ b/almalinux-9-ami.pkr.hcl
@@ -6,7 +6,7 @@ source "amazon-ebssurrogate" "almalinux-9-ami-x86_64" {
   region                  = "us-east-1"
   ssh_username            = "ec2-user"
   instance_type           = "t3.small"
-  source_ami              = "ami-0daa4c3261da5b1c4"
+  source_ami              = "ami-0845395779540e3cb"
   ami_name                = var.aws_ami_name_x86_64_9
   ami_description         = var.aws_ami_description_x86_64_9
   ami_architecture        = "x86_64"
@@ -41,7 +41,7 @@ source "amazon-ebssurrogate" "almalinux-9-ami-aarch64" {
   region                  = "us-east-1"
   ssh_username            = "ec2-user"
   instance_type           = "t4g.small"
-  source_ami              = "ami-09d6ea79e7129634e"
+  source_ami              = "ami-02e3ce0ad12576169"
   ami_name                = var.aws_ami_name_aarch64_9
   ami_description         = var.aws_ami_description_aarch64_9
   ami_architecture        = "arm64"


### PR DESCRIPTION
Update the source AMI IDs for 8-AArch64, 9-x86_64 and 9-AArch64 on EBS Surrogate Builder

Signed-off-by: Elkhan Mammadli <elkhan.mammadli@protonmail.com>