### PR TITLE
Fix version test for AlmaLinux 9.1 on DigitalOcean

### DIFF
--- a/vm-scripts/digitalocean/99-img-check.sh
+++ b/vm-scripts/digitalocean/99-img-check.sh
@@ -562,7 +562,7 @@ elif [[ $OS == "AlmaLinux" ]]; then
         ost=1
     if [[ $VER =~ 8.[3-9] ]]; then
         osv=1
-    elif [[ $VER =~ 9.0 ]]; then
+    elif [[ $VER =~ 9.? ]]; then
         osv=1
     else
         osv=2


### PR DESCRIPTION
Just generalize the pattern to match all 9.x versions, for simplicity.