### PR TITLE
Add Secure Boot support

### DIFF
--- a/almalinux-8-azure.pkr.hcl
+++ b/almalinux-8-azure.pkr.hcl
@@ -12,8 +12,8 @@ source "qemu" "almalinux-8-azure-x86_64" {
   ssh_password       = var.gencloud_ssh_password
   ssh_timeout        = var.ssh_timeout
   cpus               = var.cpus
-  firmware           = var.firmware_x86_64
-  use_pflash         = true
+  efi_firmware_code  = var.ovmf_code
+  efi_firmware_vars  = var.ovmf_vars
   disk_interface     = "virtio-scsi"
   disk_size          = var.azure_disk_size
   disk_cache         = "unsafe"

--- a/almalinux-8-gencloud.pkr.hcl
+++ b/almalinux-8-gencloud.pkr.hcl
@@ -38,8 +38,8 @@ source "qemu" "almalinux-8-gencloud-uefi-x86_64" {
   ssh_password       = var.gencloud_ssh_password
   ssh_timeout        = var.ssh_timeout
   cpus               = var.cpus
-  firmware           = var.firmware_x86_64
-  use_pflash         = true
+  efi_firmware_code  = var.ovmf_code
+  efi_firmware_vars  = var.ovmf_vars
   disk_interface     = "virtio-scsi"
   disk_size          = var.gencloud_disk_size
   disk_cache         = "unsafe"
@@ -48,6 +48,7 @@ source "qemu" "almalinux-8-gencloud-uefi-x86_64" {
   disk_compression   = true
   format             = "qcow2"
   headless           = var.headless
+  machine_type       = "q35"
   memory             = var.memory
   net_device         = "virtio-net"
   qemu_binary        = var.qemu_binary
@@ -67,7 +68,7 @@ source "qemu" "almalinux-8-gencloud-aarch64" {
   ssh_password       = var.gencloud_ssh_password
   ssh_timeout        = var.ssh_timeout
   cpus               = var.cpus
-  firmware           = var.firmware_aarch64
+  firmware           = var.aavmf_code
   use_pflash         = false
   disk_interface     = "virtio-scsi"
   disk_size          = var.gencloud_disk_size

--- a/almalinux-8-oci.pkr.hcl
+++ b/almalinux-8-oci.pkr.hcl
@@ -39,7 +39,8 @@ source "qemu" "almalinux-8-oci-uefi-x86_64" {
   ssh_password       = var.gencloud_ssh_password
   ssh_timeout        = var.ssh_timeout
   cpus               = var.cpus
-  firmware           = var.firmware_x86_64
+  efi_firmware_code  = var.ovmf_code
+  efi_firmware_vars  = var.ovmf_vars
   disk_interface     = "virtio-scsi"
   disk_size          = var.gencloud_disk_size
   disk_cache         = "unsafe"
@@ -48,6 +49,7 @@ source "qemu" "almalinux-8-oci-uefi-x86_64" {
   disk_compression   = true
   format             = "qcow2"
   headless           = var.headless
+  machine_type       = "q35"
   memory             = var.memory
   net_device         = "virtio-net"
   qemu_binary        = var.qemu_binary
@@ -67,7 +69,8 @@ source "qemu" "almalinux-8-oci-aarch64" {
   ssh_password       = var.gencloud_ssh_password
   ssh_timeout        = var.ssh_timeout
   cpus               = var.cpus
-  firmware           = var.firmware_aarch64
+  firmware           = var.aavmf_code
+  use_pflash         = false
   disk_interface     = "virtio-scsi"
   disk_size          = var.gencloud_disk_size
   disk_cache         = "unsafe"

--- a/almalinux-8-opennebula.pkr.hcl
+++ b/almalinux-8-opennebula.pkr.hcl
@@ -39,7 +39,7 @@ source "qemu" "almalinux-8-opennebula-aarch64" {
   ssh_password       = var.gencloud_ssh_password
   ssh_timeout        = var.ssh_timeout
   cpus               = var.cpus
-  firmware           = var.firmware_aarch64
+  firmware           = var.aavmf_code
   use_pflash         = false
   disk_interface     = "virtio-scsi"
   disk_size          = var.gencloud_disk_size

--- a/almalinux-9-azure.pkr.hcl
+++ b/almalinux-9-azure.pkr.hcl
@@ -12,8 +12,8 @@ source "qemu" "almalinux-9-azure-x86_64" {
   ssh_password       = var.gencloud_ssh_password
   ssh_timeout        = var.ssh_timeout
   cpus               = var.cpus
-  firmware           = var.firmware_x86_64
-  use_pflash         = true
+  efi_firmware_code  = var.ovmf_code
+  efi_firmware_vars  = var.ovmf_vars
   disk_interface     = "virtio-scsi"
   disk_size          = var.azure_disk_size
   disk_cache         = "unsafe"

--- a/almalinux-9-gencloud.pkr.hcl
+++ b/almalinux-9-gencloud.pkr.hcl
@@ -42,8 +42,8 @@ source "qemu" "almalinux-9-gencloud-x86_64" {
   ssh_password       = var.gencloud_ssh_password
   ssh_timeout        = var.ssh_timeout
   cpus               = var.cpus
-  firmware           = var.firmware_x86_64
-  use_pflash         = true
+  efi_firmware_code  = var.ovmf_code
+  efi_firmware_vars  = var.ovmf_vars
   disk_interface     = "virtio-scsi"
   disk_size          = var.gencloud_disk_size
   disk_cache         = "unsafe"
@@ -75,7 +75,7 @@ source "qemu" "almalinux-9-gencloud-aarch64" {
   ssh_password       = var.gencloud_ssh_password
   ssh_timeout        = var.ssh_timeout
   cpus               = var.cpus
-  firmware           = var.firmware_aarch64
+  firmware           = var.aavmf_code
   use_pflash         = false
   disk_interface     = "virtio-scsi"
   disk_size          = var.gencloud_disk_size

--- a/almalinux-9-oci.pkr.hcl
+++ b/almalinux-9-oci.pkr.hcl
@@ -43,8 +43,8 @@ source "qemu" "almalinux-9-oci-x86_64" {
   ssh_password       = var.gencloud_ssh_password
   ssh_timeout        = var.ssh_timeout
   cpus               = var.cpus
-  firmware           = var.firmware_x86_64
-  use_pflash         = true
+  efi_firmware_code  = var.ovmf_code
+  efi_firmware_vars  = var.ovmf_vars
   disk_interface     = "virtio-scsi"
   disk_size          = var.gencloud_disk_size
   disk_cache         = "unsafe"
@@ -76,7 +76,7 @@ source "qemu" "almalinux-9-oci-aarch64" {
   ssh_password       = var.gencloud_ssh_password
   ssh_timeout        = var.ssh_timeout
   cpus               = var.cpus
-  firmware           = var.firmware_aarch64
+  firmware           = var.aavmf_code
   use_pflash         = false
   disk_interface     = "virtio-scsi"
   disk_size          = var.gencloud_disk_size

--- a/almalinux-9-opennebula.pkr.hcl
+++ b/almalinux-9-opennebula.pkr.hcl
@@ -43,7 +43,8 @@ source "qemu" "almalinux-9-opennebula-x86_64" {
   ssh_password       = var.gencloud_ssh_password
   ssh_timeout        = var.ssh_timeout
   cpus               = var.cpus
-  firmware           = var.firmware_x86_64
+  efi_firmware_code  = var.ovmf_code
+  efi_firmware_vars  = var.ovmf_vars
   disk_interface     = "virtio-scsi"
   disk_size          = var.gencloud_disk_size
   disk_cache         = "unsafe"
@@ -75,7 +76,7 @@ source "qemu" "almalinux-9-opennebula-aarch64" {
   ssh_password       = var.gencloud_ssh_password
   ssh_timeout        = var.ssh_timeout
   cpus               = var.cpus
-  firmware           = var.firmware_aarch64
+  firmware           = var.aavmf_code
   use_pflash         = false
   disk_interface     = "virtio-scsi"
   disk_size          = var.gencloud_disk_size

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -24,8 +24,9 @@ variables {
   ssh_timeout            = "3600s"
   root_shutdown_command  = "/sbin/shutdown -hP now"
   qemu_binary            = ""
-  firmware_x86_64        = "/usr/share/OVMF/OVMF_CODE.fd"
-  firmware_aarch64       = "/usr/share/AAVMF/AAVMF_CODE.fd"
+  ovmf_code              = "/usr/share/OVMF/OVMF_CODE.secboot.fd"
+  ovmf_vars              = "/usr/share/OVMF/OVMF_VARS.secboot.fd"
+  aavmf_code             = "/usr/share/AAVMF/AAVMF_CODE.fd"
   vnc_bind_address       = "127.0.0.1"
   vnc_port_min           = 5900
   vnc_port_max           = 6000

--- a/versions.pkr.hcl
+++ b/versions.pkr.hcl
@@ -2,7 +2,7 @@ packer {
   required_version = ">= 1.7.0"
   required_plugins {
     qemu = {
-      version = ">= 1.0.3"
+      version = ">= 1.0.7"
       source  = "github.com/hashicorp/qemu"
     }
     virtualbox = {
@@ -26,7 +26,7 @@ packer {
       source  = "github.com/hashicorp/ansible"
     }
     amazon = {
-      version = ">= 1.0.0"
+      version = ">= 1.1.0"
       source  = "github.com/hashicorp/amazon"
     }
     digitalocean = {


### PR DESCRIPTION
In 1.0.7 - hashicorp/packer-plugin-qemu#100 version of the QEMU Packer plugin, it's possible to boot and build images in UEFI and with Secure Boot enabled

Signed-off-by: Elkhan Mammadli <elkhan.mammadli@protonmail.com>