### PR TITLE
Add UEFI support to Libvirt vagrant boxes

### DIFF
--- a/almalinux-9-vagrant.pkr.hcl
+++ b/almalinux-9-vagrant.pkr.hcl
@@ -5,7 +5,7 @@
 source "hyperv-iso" "almalinux-9" {
   iso_url               = var.iso_url_9_x86_64
   iso_checksum          = var.iso_checksum_9_x86_64
-  boot_command          = var.vagrant_efi_boot_command_9_x86_64
+  boot_command          = var.vagrant_boot_command_9_x86_64_uefi
   boot_wait             = var.boot_wait
   generation            = 2
   switch_name           = var.hyperv_switch_name
@@ -102,6 +102,8 @@ source "qemu" "almalinux-9" {
   ssh_password       = var.vagrant_ssh_password
   ssh_timeout        = var.ssh_timeout
   cpus               = var.cpus
+  efi_firmware_code  = var.ovmf_code
+  efi_firmware_vars  = var.ovmf_vars
   disk_interface     = "virtio-scsi"
   disk_size          = var.vagrant_disk_size
   disk_cache         = "unsafe"
@@ -116,7 +118,7 @@ source "qemu" "almalinux-9" {
   qemu_binary        = var.qemu_binary
   vm_name            = "almalinux-9"
   boot_wait          = var.boot_wait
-  boot_command       = var.vagrant_boot_command_9_x86_64
+  boot_command       = var.vagrant_boot_command_9_x86_64_uefi
   qemuargs = [
     ["-cpu", "host"]
   ]

--- a/http/almalinux-8.vagrant.ks
+++ b/http/almalinux-8.vagrant.ks
@@ -7,6 +7,7 @@ repo --name=AppStream --baseurl=https://repo.almalinux.org/almalinux/8/AppStream
 
 text
 skipx
+eula --agreed
 firstboot --disabled
 
 lang en_US.UTF-8
@@ -21,7 +22,7 @@ selinux --enforcing
 bootloader --location=mbr
 zerombr
 clearpart --all --initlabel
-autopart --type=plain --nohome --noboot
+autopart --type=plain --nohome --noboot --noswap
 
 rootpw vagrant
 user --name=vagrant --plaintext --password vagrant

--- a/tpl/vagrant/vagrantfile-libvirt-uefi.tpl
+++ b/tpl/vagrant/vagrantfile-libvirt-uefi.tpl
@@ -1,0 +1,14 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.synced_folder ".", "/vagrant", type: "rsync"
+  config.vm.provider :libvirt do |libvirt|
+    libvirt.driver = "kvm"
+    libvirt.connect_via_ssh = false
+    libvirt.username = "root"
+    libvirt.storage_pool_name = "default"
+    libvirt.loader = "/usr/share/OVMF/OVMF_CODE.fd"
+    libvirt.machine_type = "q35"
+  end
+end

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -159,13 +159,18 @@ variables {
   vagrant_boot_command_8_x86_64 = [
     "<tab> inst.text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-8.vagrant.ks<enter><wait>"
   ]
+  vagrant_boot_command_8_x86_64_uefi = [
+    "c<wait>",
+    "linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=AlmaLinux-8-7-x86_64-dvd ro ",
+    "inst.text biosdevname=0 net.ifnames=0 ",
+    "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-8.vagrant.ks<enter>",
+    "initrdefi /images/pxeboot/initrd.img<enter>",
+    "boot<enter><wait>"
+  ]
   vagrant_boot_command_9_x86_64 = [
     "<tab> inst.text inst.gpt inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-9.vagrant.ks<enter><wait>"
   ]
-  vagrant_efi_boot_command_8_x86_64 = [
-    "e<down><down><end><bs><bs><bs><bs><bs>inst.text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-8.vagrant.ks<leftCtrlOn>x<leftCtrlOff>"
-  ]
-  vagrant_efi_boot_command_9_x86_64 = [
+  vagrant_boot_command_9_x86_64_uefi = [
     "c<wait>",
     "linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL=AlmaLinux-9-1-x86_64-dvd ro ",
     "inst.text biosdevname=0 net.ifnames=0 ",


### PR DESCRIPTION
* Added new UEFI only vagrant box for AlmaLinux 8 at almalinux/8.uefi
* Added BIOS + UEFI support AlmaLinux OS 9 box at almalinux/9
* Don't create swap partition on AlmaLinux OS 8 vagrant box

Signed-off-by: Elkhan Mammadli <elkhan.mammadli@protonmail.com>