### PR TITLE
Remove Yum Infra Variable

### DIFF
--- a/ansible/roles/azure_guest/tasks/main.yml
+++ b/ansible/roles/azure_guest/tasks/main.yml
@@ -22,14 +22,6 @@
     - blacklist lbm-nouveau
     - blacklist floppy
 
-- name: Set infra yum variable to 'azure'
-  copy:
-    content: 'azure'
-    dest: /etc/yum/vars/infra
-    owner: root
-    group: root
-    mode: 0644
-
 - name: Enable NetworkManager service
   service:
     name: NetworkManager

--- a/ansible/roles/digitalocean_guest/tasks/main.yml
+++ b/ansible/roles/digitalocean_guest/tasks/main.yml
@@ -80,14 +80,6 @@
     mode: 0644
     seuser: system_u
 
-
-- name: Set infra yum variable to 'genclo'
-  replace:
-    path: /etc/yum/vars/infra
-    regexp: '^(.*?)$'
-    replace: 'genclo'
-  when: ansible_facts['distribution_major_version'] == '8'
-
 - name: Set default kernel package type to kernel
   replace:
     path: /etc/sysconfig/kernel

--- a/ansible/roles/gencloud_guest/tasks/main.yml
+++ b/ansible/roles/gencloud_guest/tasks/main.yml
@@ -80,13 +80,6 @@
     mode: 0644
     seuser: system_u
 
-- name: Set infra yum variable to 'genclo'
-  replace:
-    path: /etc/yum/vars/infra
-    regexp: '^(.*?)$'
-    replace: 'genclo'
-  when: ansible_facts['distribution_major_version'] == '8'
-
 - name: Set default kernel package type to kernel
   replace:
     path: /etc/sysconfig/kernel

--- a/tests/azure/test_azure.py
+++ b/tests/azure/test_azure.py
@@ -78,14 +78,6 @@ def test_kmod_blacklist(host, kmod):
         assert blacklist.contains('options nouveau modeset=0')
 
 
-def test_infra_yum_variable(host):
-    """'infra' yum variable should be set to 'azure'."""
-    file_path = '/etc/yum/vars/infra'
-    assert host.file(file_path).content_string.strip() == 'azure'
-    context = host.run(f'ls -Z {file_path} | cut -d " " -f 1').stdout.strip()
-    assert context == 'system_u:object_r:etc_t:s0'
-
-
 def test_network_manager_enabled(host):
     """NetworkManager should be running."""
     nm = host.service('NetworkManager')


### PR DESCRIPTION
Although the file was created for the CentOS Mirror System, it was never used. We used to for backward compatibility for users who is migrated from CentOS, since the almalinux-release package
overwrites it on each upgrade, no need to write any value to it

Signed-off-by: Elkhan Mammadli <elkhan.mammadli@protonmail.com>