### PR TITLE
Disable swap file creation by WALinuxAgent

### DIFF
--- a/ansible/roles/azure_guest/tasks/main.yml
+++ b/ansible/roles/azure_guest/tasks/main.yml
@@ -60,24 +60,10 @@
     name: WALinuxAgent
     state: present
 
-- name: Enable swap on resource disk
-  lineinfile:
-    path: /etc/waagent.conf
-    regexp: '^ResourceDisk\.EnableSwap='
-    line: 'ResourceDisk.EnableSwap=y'
-    state: present
-
-- name: Set resource disk swap size to 2048
-  lineinfile:
-    path: /etc/waagent.conf
-    regexp: '^ResourceDisk.SwapSizeMB='
-    line: 'ResourceDisk.SwapSizeMB=2048'
-    state: present
-
 - name: Enable waagent service
-  service:
-    name: waagent
-    enabled: true
+  ansible.builtin.systemd:
+    name: waagent.service
+    enabled: yes
 
 - name: Set sshd ClientAliveInterval to 180
   lineinfile:
@@ -151,4 +137,4 @@
     mode: 0644
 
 - name: Update initramfs
-  command: dracut -f -v
+  command: dracut -f --regenerate-all

--- a/tests/azure/test_azure.py
+++ b/tests/azure/test_azure.py
@@ -161,9 +161,6 @@ def test_walinuxagent_config(host):
     # resource disk formatting should be enabled
     assert re.search(r'^ResourceDisk\.Format=y$', content,
                      flags=re.MULTILINE) is not None
-    # resource disk swap size should be 2048
-    assert re.search(r'^ResourceDisk\.SwapSizeMB=2048$', content,
-                     flags=re.MULTILINE) is not None
 
 
 def test_sshd_config(host):


### PR DESCRIPTION
Creating of the swap file by WALinuxAgent on boot, is against to Commercial marketplace certification policies.
Since this option is disabled by default,
removing the ResourceDisk.EnableSwap=y configuration option is enough

Signed-off-by: Elkhan Mammadli <elkhan.mammadli@protonmail.com>