### PR TITLE
Remove DHCP timeout configuration for dhclient

### DIFF
--- a/ansible/roles/azure_guest/tasks/main.yml
+++ b/ansible/roles/azure_guest/tasks/main.yml
@@ -35,18 +35,9 @@
     group: root
     mode: 0644
 
-- name: Configure dhclient
-  lineinfile:
-    path: /etc/dhcp/dhclient.conf
-    line: "{{ item }}"
-  with_items:
-    - 'timeout 300;'
-    - 'retry 60;'
-  when: ansible_facts['distribution_major_version'] == '8'
-
 - name: Configure NetworkManager default DHCP timeout
   community.general.ini_file:
-    path: /etc/NetworkManager/conf.d/dhcp.conf
+    path: /etc/NetworkManager/conf.d/99-dhcp-timeout.conf
     section: connection
     option: ipv4.dhcp-timeout
     value: 300

--- a/tests/azure/test_azure.py
+++ b/tests/azure/test_azure.py
@@ -85,19 +85,9 @@ def test_network_manager_enabled(host):
     assert nm.is_enabled
 
 
-def test_dhclient_timeout(host):
-    """dhclient timeout should be 300 seconds."""
-    if int(host.system_info.release[0]) > 8:
-        pytest.skip('deprecated on EL>=9')
-    with host.sudo():
-        content = host.file('/etc/dhcp/dhclient.conf').content_string
-        re_rslt = re.search(r'^timeout\s+(\d+);', content, flags=re.MULTILINE)
-        assert re_rslt.group(1) == '300'
-
-
 def test_network_manager_default_dhcp_timeout(host):
     """NetworkManager default DHCP timeout should be 300 seconds."""
-    file_path = '/etc/NetworkManager/conf.d/dhcp.conf'
+    file_path = '/etc/NetworkManager/conf.d/99-dhcp-timeout.conf'
     dhcp_conf = host.file(file_path)
     assert dhcp_conf.user == 'root'
     assert dhcp_conf.group == 'root'


### PR DESCRIPTION
Starting with EL8, the NetworkManager uses its internal dhcp client. Therefore, it renders the default dhcp client timeout configuration on /etc/dhcp/dhclient.conf ineffective.

Signed-off-by: Elkhan Mammadli <elkhan.mammadli@protonmail.com>