### PR TITLE
Use grub2-pc package instead of grub2-pc-modules

### DIFF
--- a/http/almalinux-8.azure-x86_64.ks
+++ b/http/almalinux-8.azure-x86_64.ks
@@ -38,7 +38,7 @@ reboot --eject
 %packages
 @core
 @standard
-grub2-pc-modules
+grub2-pc
 
 -biosdevname
 -open-vm-tools


### PR DESCRIPTION
Since the grub2-pc-modules itself is a dependency of grub2-pc and grub2-pc has more dependency than the grub2-pc-modules. Use the grub2-pc to make sure all requirements
for BIOS boot is met and more complete

Signed-off-by: Elkhan Mammadli <elkhan.mammadli@protonmail.com>