### PR TITLE
Some enhancements and modernization for AMIs

### DIFF
--- a/almalinux-8-aws-aarch64.pkr.hcl
+++ b/almalinux-8-aws-aarch64.pkr.hcl
@@ -2,16 +2,27 @@
  * AlmaLinux OS 8 Packer template for building aarch64 AWS images.
  */
 
+data "amazon-ami" "almalinux-8-aarch64" {
+  filters = {
+    name         = "AlmaLinux OS 8.*"
+    architecture = "arm64"
+    is-public    = true
+  }
+  owners      = ["764336703387"]
+  most_recent = true
+}
+
+
 source "amazon-ebssurrogate" "almalinux-8-aws-aarch64" {
-  region                  = "us-east-1"
+  region                  = var.aws_ami_region
   ssh_username            = "ec2-user"
-  instance_type           = "t4g.micro"
-  source_ami              = "ami-02c9a8bba92028114"
+  instance_type           = "t4g.small"
+  source_ami              = data.amazon-ami.almalinux-8-aarch64.id
   ami_name                = local.aws_ami_name_aarch64_8
   ami_description         = local.aws_ami_description_aarch64_8
   ami_architecture        = "arm64"
   ami_virtualization_type = "hvm"
-  ami_regions             = ["us-east-1"]
+  ami_regions             = var.aws_ami_regions
   tags = {
     Name         = "${local.aws_ami_name_aarch64_8}",
     Version      = "${local.aws_ami_version_8}",
@@ -24,14 +35,14 @@ source "amazon-ebssurrogate" "almalinux-8-aws-aarch64" {
   launch_block_device_mappings {
     device_name           = "/dev/sdb"
     volume_size           = 4
-    volume_type           = "gp2"
+    volume_type           = var.aws_volume_type
     delete_on_termination = true
   }
   ami_root_device {
     source_device_name    = "/dev/sdb"
     device_name           = "/dev/sda1"
     volume_size           = 10
-    volume_type           = "gp2"
+    volume_type           = var.aws_volume_type
     delete_on_termination = true
   }
 }
@@ -49,5 +60,4 @@ build {
     playbook_file = "./ansible/aws-ami-aarch64.yml"
     galaxy_file   = "./ansible/requirements.yml"
   }
-
 }

--- a/almalinux-8-aws-stage1.pkr.hcl
+++ b/almalinux-8-aws-stage1.pkr.hcl
@@ -51,7 +51,7 @@ source "qemu" "almalinux-8-aws-stage1" {
   memory             = var.memory
   net_device         = "virtio-net"
   qemu_binary        = var.qemu_binary
-  vm_name            = "almalinux-8-AWS-${var.os_ver_8}.x86_64.raw"
+  vm_name            = "AlmaLinux-8-AWS-${var.os_ver_8}-${formatdate("YYYYMMDD", timestamp())}.x86_64.raw"
   boot_wait          = var.boot_wait
   boot_command       = var.aws_boot_command_8
 }
@@ -77,14 +77,14 @@ build {
 
   // comment this out if you don't want to import AMI to Amazon EC2 automatically
   post-processor "amazon-import" {
-    ami_name        = "Alma ${var.os_ver_8} internal use only {{isotime \"20060102\"}} x86_64"
+    ami_name        = "Alma ${var.os_ver_8} internal use only ${formatdate("YYYYMMDD", timestamp())} x86_64"
     ami_description = local.aws_ami_description_x86_64_8
     ami_groups      = ["all"]
     s3_bucket_name  = var.aws_s3_bucket_name
     license_type    = "BYOL"
     role_name       = var.aws_role_name
     tags = {
-      Name = "Alma ${var.os_ver_8} internal use only {{isotime \"20060102\"}} x86_64"
+      Name = "Alma ${var.os_ver_8} internal use only ${formatdate("YYYYMMDD", timestamp())} x86_64"
     }
     keep_input_artifact = true
     except = [
@@ -93,7 +93,7 @@ build {
   }
 
   post-processor "amazon-import" {
-    ami_name        = "Alma ${var.os_ver_8} internal use only {{isotime \"20060102\"}} x86_64"
+    ami_name        = "Alma ${var.os_ver_8} internal use only ${formatdate("YYYYMMDD", timestamp())} x86_64"
     format          = "raw"
     ami_description = local.aws_ami_description_x86_64_8
     ami_groups      = ["all"]
@@ -101,7 +101,7 @@ build {
     license_type    = "BYOL"
     role_name       = var.aws_role_name
     tags = {
-      Name = "Alma ${var.os_ver_8} internal use only {{isotime \"20060102\"}} x86_64"
+      Name = "Alma ${var.os_ver_8} internal use only ${formatdate("YYYYMMDD", timestamp())} x86_64"
     }
     keep_input_artifact = true
     only = [

--- a/almalinux-8-aws-stage2.pkr.hcl
+++ b/almalinux-8-aws-stage2.pkr.hcl
@@ -6,7 +6,7 @@ source "amazon-chroot" "almalinux-8-aws-stage2" {
   ami_name                = local.aws_ami_name_x86_64_8
   ami_description         = local.aws_ami_description_x86_64_8
   ami_virtualization_type = "hvm"
-  ami_regions             = ["us-east-1"]
+  ami_regions             = var.aws_ami_regions
   tags = {
     Name         = "${local.aws_ami_name_x86_64_8}",
     Version      = "${local.aws_ami_version_8}",
@@ -14,7 +14,7 @@ source "amazon-chroot" "almalinux-8-aws-stage2" {
   }
   ena_support     = true
   sriov_support   = true
-  region          = "us-east-1"
+  region          = var.aws_ami_region
   device_path     = "/dev/xvdb"
   mount_options   = ["nouuid"]
   mount_partition = "2"
@@ -32,7 +32,7 @@ source "amazon-chroot" "almalinux-8-aws-stage2" {
   ami_block_device_mappings {
     device_name           = "/dev/sda1"
     delete_on_termination = true
-    volume_type           = "gp2"
+    volume_type           = var.aws_volume_type
   }
 }
 

--- a/almalinux-9-ami.pkr.hcl
+++ b/almalinux-9-ami.pkr.hcl
@@ -2,16 +2,37 @@
  * AlmaLinux OS 9 Packer template for building Amazon Machine Images (AMI).
  */
 
+data "amazon-ami" "almalinux-9-x86_64" {
+  filters = {
+    name         = "AlmaLinux OS 9.*"
+    architecture = "x86_64"
+    is-public    = true
+  }
+  owners      = ["764336703387"]
+  most_recent = true
+}
+
+data "amazon-ami" "almalinux-9-aarch64" {
+  filters = {
+    name         = "AlmaLinux OS 9.*"
+    architecture = "arm64"
+    is-public    = true
+  }
+  owners      = ["764336703387"]
+  most_recent = true
+}
+
+
 source "amazon-ebssurrogate" "almalinux-9-ami-x86_64" {
-  region                  = "us-east-1"
+  region                  = var.aws_ami_region
   ssh_username            = "ec2-user"
   instance_type           = "t3.small"
-  source_ami              = "ami-0845395779540e3cb"
+  source_ami              = data.amazon-ami.almalinux-9-x86_64.id
   ami_name                = local.aws_ami_name_x86_64_9
   ami_description         = local.aws_ami_description_x86_64_9
   ami_architecture        = "x86_64"
   ami_virtualization_type = "hvm"
-  ami_regions             = ["us-east-1"]
+  ami_regions             = var.aws_ami_regions
   tags = {
     Name         = "${local.aws_ami_name_x86_64_9}",
     Version      = "${local.aws_ami_version_9}",
@@ -24,29 +45,29 @@ source "amazon-ebssurrogate" "almalinux-9-ami-x86_64" {
   launch_block_device_mappings {
     device_name           = "/dev/sdb"
     volume_size           = 4
-    volume_type           = "gp2"
+    volume_type           = var.aws_volume_type
     delete_on_termination = true
   }
   ami_root_device {
     source_device_name    = "/dev/sdb"
     device_name           = "/dev/sda1"
     volume_size           = 10
-    volume_type           = "gp2"
+    volume_type           = var.aws_volume_type
     delete_on_termination = true
   }
 }
 
 
 source "amazon-ebssurrogate" "almalinux-9-ami-aarch64" {
-  region                  = "us-east-1"
+  region                  = var.aws_ami_region
   ssh_username            = "ec2-user"
   instance_type           = "t4g.small"
-  source_ami              = "ami-02e3ce0ad12576169"
+  source_ami              = data.amazon-ami.almalinux-9-aarch64.id
   ami_name                = local.aws_ami_name_aarch64_9
   ami_description         = local.aws_ami_description_aarch64_9
   ami_architecture        = "arm64"
   ami_virtualization_type = "hvm"
-  ami_regions             = ["us-east-1"]
+  ami_regions             = var.aws_ami_regions
   tags = {
     Name         = "${local.aws_ami_name_aarch64_9}",
     Version      = "${local.aws_ami_version_9}",
@@ -59,14 +80,14 @@ source "amazon-ebssurrogate" "almalinux-9-ami-aarch64" {
   launch_block_device_mappings {
     device_name           = "/dev/sdb"
     volume_size           = 4
-    volume_type           = "gp2"
+    volume_type           = var.aws_volume_type
     delete_on_termination = true
   }
   ami_root_device {
     source_device_name    = "/dev/sdb"
     device_name           = "/dev/sda1"
     volume_size           = 10
-    volume_type           = "gp2"
+    volume_type           = var.aws_volume_type
     delete_on_termination = true
   }
 }

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -393,6 +393,27 @@ variable "aws_ami_architecture" {
   default = "x86_64"
 }
 
+variable "aws_ami_region" {
+  description = "The region to create the AMI"
+
+  type    = string
+  default = "us-east-1"
+}
+
+variable "aws_ami_regions" {
+  description = "The list of regions to copy the AMI to"
+
+  type    = list(string)
+  default = ["us-east-1"]
+}
+
+variable "aws_volume_type" {
+  description = "Volume type for AMI"
+
+  type    = string
+  default = "gp3"
+}
+
 variable "aws_boot_command_8" {
   description = "Boot command for x86_64 BIOS"
 


### PR DESCRIPTION
- Use Data Sources to fetch latest source AMI IDs for 8-aarch64, 9-x86_64, and 9-aarch64 AMIs instead of the static IDs
- Make the region to create the AMI and list of regions to copy the AMI dynamic via input variables
- Make volume type dynamic via input variables and change the default type from gp2 to gp3 for lower price and better performance
- Replace legacy JSON style isotime with formatdate() and timestamp() Packer functions