### PR TITLE
Add VirtualBox 7 and UEFI support

### DIFF
--- a/almalinux-8-vagrant.pkr.hcl
+++ b/almalinux-8-vagrant.pkr.hcl
@@ -58,6 +58,9 @@ source "virtualbox-iso" "almalinux-8" {
   ssh_password         = var.vagrant_ssh_password
   ssh_timeout          = var.ssh_timeout
   hard_drive_interface = "sata"
+  vboxmanage = [
+    ["modifyvm", "{{.Name}}", "--nat-localhostreachable1", "on"],
+  ]
   vboxmanage_post = [
     ["modifyvm", "{{.Name}}", "--memory", var.post_memory],
     ["modifyvm", "{{.Name}}", "--cpus", var.post_cpus]

--- a/almalinux-9-vagrant.pkr.hcl
+++ b/almalinux-9-vagrant.pkr.hcl
@@ -60,7 +60,7 @@ source "parallels-iso" "almalinux-9-aarch64" {
 source "virtualbox-iso" "almalinux-9" {
   iso_url              = local.iso_url_9_x86_64
   iso_checksum         = local.iso_checksum_9_x86_64
-  boot_command         = var.vagrant_boot_command_9_x86_64_bios
+  boot_command         = var.vagrant_boot_command_9_x86_64
   boot_wait            = var.boot_wait
   cpus                 = var.cpus
   memory               = var.memory
@@ -73,6 +73,10 @@ source "virtualbox-iso" "almalinux-9" {
   ssh_password         = var.vagrant_ssh_password
   ssh_timeout          = var.ssh_timeout
   hard_drive_interface = "sata"
+  iso_interface        = "sata"
+  vboxmanage = [
+    ["modifyvm", "{{.Name}}", "--nat-localhostreachable1", "on"],
+  ]
   vboxmanage_post = [
     ["modifyvm", "{{.Name}}", "--memory", var.post_memory],
     ["modifyvm", "{{.Name}}", "--cpus", var.post_cpus]
@@ -95,6 +99,9 @@ source "virtualbox-iso" "almalinux-9-aarch64" {
   ssh_password         = var.vagrant_ssh_password
   ssh_timeout          = var.ssh_timeout
   hard_drive_interface = "sata"
+  vboxmanage = [
+    ["modifyvm", "{{.Name}}", "--nat-localhostreachable1", "on"],
+  ]
   vboxmanage_post = [
     ["modifyvm", "{{.Name}}", "--memory", var.post_memory],
     ["modifyvm", "{{.Name}}", "--cpus", var.post_cpus]


### PR DESCRIPTION
- Add support for VirtualBox 7
- Add BIOS and UEFI support to AlmaLinux 9 boxes and make UEFI as a default firmware

Fixes #120 