### PR TITLE
Use input variables as Source AMI and Vagrant fix

### DIFF
--- a/almalinux-8-aws-aarch64.pkr.hcl
+++ b/almalinux-8-aws-aarch64.pkr.hcl
@@ -2,6 +2,9 @@
  * AlmaLinux OS 8 Packer template for building aarch64 AWS images.
  */
 
+
+# TODO: Enable when https://github.com/hashicorp/packer/issues/12434 is resolved
+/*
 data "amazon-ami" "almalinux-8-aarch64" {
   filters = {
     name         = "AlmaLinux OS 8.*"
@@ -11,13 +14,14 @@ data "amazon-ami" "almalinux-8-aarch64" {
   owners      = ["764336703387"]
   most_recent = true
 }
+*/
 
 
 source "amazon-ebssurrogate" "almalinux-8-aws-aarch64" {
   region                  = var.aws_ami_region
   ssh_username            = "ec2-user"
   instance_type           = "t4g.small"
-  source_ami              = data.amazon-ami.almalinux-8-aarch64.id
+  source_ami              = var.aws_source_ami_8_aarch64
   ami_name                = local.aws_ami_name_aarch64_8
   ami_description         = local.aws_ami_description_aarch64_8
   ami_architecture        = "arm64"

--- a/almalinux-9-ami.pkr.hcl
+++ b/almalinux-9-ami.pkr.hcl
@@ -2,6 +2,9 @@
  * AlmaLinux OS 9 Packer template for building Amazon Machine Images (AMI).
  */
 
+
+# TODO: Enable when https://github.com/hashicorp/packer/issues/12434 is resolved
+/*
 data "amazon-ami" "almalinux-9-x86_64" {
   filters = {
     name         = "AlmaLinux OS 9.*"
@@ -21,13 +24,13 @@ data "amazon-ami" "almalinux-9-aarch64" {
   owners      = ["764336703387"]
   most_recent = true
 }
-
+*/
 
 source "amazon-ebssurrogate" "almalinux-9-ami-x86_64" {
   region                  = var.aws_ami_region
   ssh_username            = "ec2-user"
   instance_type           = "t3.small"
-  source_ami              = data.amazon-ami.almalinux-9-x86_64.id
+  source_ami              = var.aws_source_ami_9_x86_64
   ami_name                = local.aws_ami_name_x86_64_9
   ami_description         = local.aws_ami_description_x86_64_9
   ami_architecture        = "x86_64"
@@ -62,7 +65,7 @@ source "amazon-ebssurrogate" "almalinux-9-ami-aarch64" {
   region                  = var.aws_ami_region
   ssh_username            = "ec2-user"
   instance_type           = "t4g.small"
-  source_ami              = data.amazon-ami.almalinux-9-aarch64.id
+  source_ami              = var.aws_source_ami_9_aarch64
   ami_name                = local.aws_ami_name_aarch64_9
   ami_description         = local.aws_ami_description_aarch64_9
   ami_architecture        = "arm64"

--- a/almalinux-9-vagrant.pkr.hcl
+++ b/almalinux-9-vagrant.pkr.hcl
@@ -60,7 +60,7 @@ source "parallels-iso" "almalinux-9-aarch64" {
 source "virtualbox-iso" "almalinux-9" {
   iso_url              = local.iso_url_9_x86_64
   iso_checksum         = local.iso_checksum_9_x86_64
-  boot_command         = var.vagrant_boot_command_9_x86_64
+  boot_command         = local.vagrant_boot_command_9_x86_64
   boot_wait            = var.boot_wait
   cpus                 = var.cpus
   memory               = var.memory
@@ -74,6 +74,7 @@ source "virtualbox-iso" "almalinux-9" {
   ssh_timeout          = var.ssh_timeout
   hard_drive_interface = "sata"
   iso_interface        = "sata"
+  firmware             = "efi"
   vboxmanage = [
     ["modifyvm", "{{.Name}}", "--nat-localhostreachable1", "on"],
   ]

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -414,6 +414,27 @@ variable "aws_volume_type" {
   default = "gp3"
 }
 
+variable "aws_source_ami_8_aarch64" {
+  description = "AlmaLinux OS 8 AArch64 AMI as source"
+
+  type    = string
+  default = "ami-02c9a8bba92028114"
+}
+
+variable "aws_source_ami_9_x86_64" {
+  description = "AlmaLinux OS 9 x86_64 AMI as source"
+
+  type    = string
+  default = "ami-06bc84fafec254e1d"
+}
+
+variable "aws_source_ami_9_aarch64" {
+  description = "AlmaLinux OS 9 AArch64 AMI as source"
+
+  type    = string
+  default = "ami-00a3e427999640fad"
+}
+
 variable "aws_boot_command_8" {
   description = "Boot command for x86_64 BIOS"
 


### PR DESCRIPTION
AMI related changes:

When fetching the latest AMI IDs via amazon-ami data source, this data source executes on non AMI images also. Which gives error on a system without any AWS authentication setup up. Let's file a bug report for Packer and use the input variables as source AMI IDs for now

Vagrant related fix:

- Fix boot command for AlmaLinux OS 9 for VirtualBox provider
- Add efi as firmware option