### PR TITLE
OCI: Add Oracle as Cloud-init Datasource

### DIFF
--- a/ansible/roles/oci_guest/defaults/main.yml
+++ b/ansible/roles/oci_guest/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 # https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/manage-plugins.htm#install-agent__manual-linux
 # Click on "Oracle Linux" >> "Oracle Linux 8.x, Oracle Linux Cloud Developer 8.x"
-ol8_gpg_key_url: "https://yum.oracle.com/RPM-GPG-KEY-oracle-ol8"
-oracle_cloud_agent_url_x86_64: "https://objectstorage.us-phoenix-1.oraclecloud.com/p/fBz9tPaD_wjqB8E_w3bUQUKSayY9TziAnVRWrhvLGBiWmuEn8QnvHpZxqq6NpnRH/n/imagegen/b/agents/o/oracle-cloud-agent-1.24.0-7254.el8.x86_64.rpm"
-oracle_cloud_agent_url_aarch64: "https://objectstorage.us-phoenix-1.oraclecloud.com/p/KSx-PVVSqGVkawlHVcFxGR3ZWAfdNz3-lTB84LwFiw72lMUWzpfrByT_VbjqrtCI/n/imagegen/b/agents/o/oracle-cloud-agent-1.24.0-1.el8.aarch64.rpm"
+# The public download links of Oracle Cloud Agent are not available anymore
+# ol8_gpg_key_url: ""
+# oracle_cloud_agent_url_x86_64: ""
+# oracle_cloud_agent_url_aarch64: ""

--- a/ansible/roles/oci_guest/meta/main.yml
+++ b/ansible/roles/oci_guest/meta/main.yml
@@ -4,4 +4,5 @@ dependencies:
   - role: "setup_cloud_init"
     vars:
       cloud_init_user: "opc"
+      cloud_platform: "oci"
   - role: qemu_guest

--- a/ansible/roles/oci_guest/tasks/main.yml
+++ b/ansible/roles/oci_guest/tasks/main.yml
@@ -123,35 +123,36 @@
     - '# Oracle Cloud Infrastructure NTP Service'
     - 'server 169.254.169.254 prefer iburst'
 
-- name: Set up Oracle Cloud Agent
-  block:
-    - name: Import Oracle Linux 8 GPG Public key
-      rpm_key:
-        state: present
-        key: "{{ ol8_gpg_key_url }}"
-      when: ansible_facts['distribution_major_version'] == '8'
-
-    - name: Install Oracle Cloud Agent
-      dnf:
-        name:
-          - "{{ oracle_cloud_agent_url_x86_64 }}"
-          - librepo
-          - python3-librepo
-        state: present
-      when:
-        - ansible_facts['architecture'] == 'x86_64'
-        - ansible_facts['distribution_major_version'] == '8'
-
-    - name: Install Oracle Cloud Agent
-      dnf:
-        name:
-          - "{{ oracle_cloud_agent_url_aarch64 }}"
-          - librepo
-          - python3-librepo
-        state: present
-      when:
-        - ansible_facts['architecture'] == 'aarch64'
-        - ansible_facts['distribution_major_version'] == '8'
+# The public download links of Oracle Cloud Agent are not available anymore
+# - name: Set up Oracle Cloud Agent
+#   block:
+#     - name: Import Oracle Linux 8 GPG Public key
+#       rpm_key:
+#         state: present
+#         key: "{{ ol8_gpg_key_url }}"
+#       when: ansible_facts['distribution_major_version'] == '8'
+#
+#     - name: Install Oracle Cloud Agent
+#       dnf:
+#         name:
+#           - "{{ oracle_cloud_agent_url_x86_64 }}"
+#           - librepo
+#           - python3-librepo
+#         state: present
+#       when:
+#         - ansible_facts['architecture'] == 'x86_64'
+#         - ansible_facts['distribution_major_version'] == '8'
+#
+#     - name: Install Oracle Cloud Agent
+#       dnf:
+#         name:
+#           - "{{ oracle_cloud_agent_url_aarch64 }}"
+#           - librepo
+#           - python3-librepo
+#         state: present
+#       when:
+#         - ansible_facts['architecture'] == 'aarch64'
+#         - ansible_facts['distribution_major_version'] == '8'
 
 - name: Permit only SSH service on firewalld
   firewalld:

--- a/ansible/roles/setup_cloud_init/files/99_oci.cfg
+++ b/ansible/roles/setup_cloud_init/files/99_oci.cfg
@@ -1,0 +1,8 @@
+datasource_list: ['Oracle', 'OpenStack']
+datasource:
+  Oracle:
+    configure_secondary_nics: true
+  OpenStack:
+    metadata_urls: ['http://169.254.169.254']
+    timeout: 10
+    max_wait: 20

--- a/ansible/roles/setup_cloud_init/tasks/main.yml
+++ b/ansible/roles/setup_cloud_init/tasks/main.yml
@@ -25,3 +25,6 @@
 
 - include_tasks: azure.yml
   when: cloud_platform == 'azure'
+
+- ansible.builtin.include_tasks: oci.yaml
+  when: cloud_platform == 'oci'

--- a/ansible/roles/setup_cloud_init/tasks/oci.yaml
+++ b/ansible/roles/setup_cloud_init/tasks/oci.yaml
@@ -1,0 +1,8 @@
+---
+- name: Configure Oracle Cloud-init Datasource
+  ansible.builtin.copy:
+    src: 99_oci.cfg
+    dest: /etc/cloud/cloud.cfg.d/99_oci.cfg
+    owner: root
+    group: root
+    mode: "0644"


### PR DESCRIPTION
- Add "Oracle" as a supported and preferred Cloud-init Datasource
- Enable configure_secondary_nics in Oracle Datasource
- Oracle Cloud Agent: Since public download URLs is not available anymore, disable the installation by default