### PR TITLE
Install nvme-cli on Azure images

### DIFF
--- a/ansible/roles/azure_guest/tasks/main.yml
+++ b/ansible/roles/azure_guest/tasks/main.yml
@@ -6,6 +6,7 @@
       - gdisk
       - tar
       - yum-utils
+      - nvme-cli
     state: present
 
 - name: Blacklist unnecessary kernel modules


### PR DESCRIPTION
We already have nvme in our initramfs, enhance NVMe support with installation of nvme-cli package