### PR TITLE
Bump Packer's Ansible plugin version to 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -720,6 +720,15 @@ Add `extra_arguments  = [ "--scp-extra-args", "'-O'" ]` to the Packer's Ansible 
 
 ### Packer's Ansible Plugin can't connect via SSH on SHA1 disabled system
 
+**FIXED:** Starting with the `1.1.0` version, `ECDSA` keypair is generated and used by default instead of `RSA`.
+
+To upgrade the plugin and disable SHA1:
+
+```sh
+packer init -upgrade .
+update-crypto-policies --set DEFAULT
+```
+
 Error output:
 
 ```sh

--- a/versions.pkr.hcl
+++ b/versions.pkr.hcl
@@ -22,7 +22,7 @@ packer {
       source  = "github.com/hashicorp/parallels"
     }
     ansible = {
-      version = ">= 1.0.3"
+      version = ">= 1.1.0"
       source  = "github.com/hashicorp/ansible"
     }
     amazon = {


### PR DESCRIPTION
This version introduces generation of ECDSA keypairs. Which means we don't need to enable SHA1 on AlmaLinux OS 9 anymore.

- Bump the minimal version to 1.1.0.
- Update the documentation how to disable SHA1.

Thanks to: https://github.com/hashicorp/packer-plugin-ansible/pull/162