### PR TITLE
Bump minimal packer plugin versions for rsa-sha2

### DIFF
--- a/versions.pkr.hcl
+++ b/versions.pkr.hcl
@@ -6,19 +6,19 @@ packer {
       source  = "github.com/hashicorp/qemu"
     }
     virtualbox = {
-      version = ">= 1.0.0"
+      version = ">= 1.0.3"
       source  = "github.com/hashicorp/virtualbox"
     }
     vmware = {
-      version = ">= 1.0.0"
+      version = ">= 1.0.6"
       source  = "github.com/hashicorp/vmware"
     }
     hyperv = {
-      version = ">= 1.0.0"
+      version = ">= 1.0.3"
       source  = "github.com/hashicorp/hyperv"
     }
     parallels = {
-      version = ">= 1.0.0"
+      version = ">= 1.0.2"
       source  = "github.com/hashicorp/parallels"
     }
     ansible = {


### PR DESCRIPTION
Make sue all the plugins has the needed version for rsa-sha2 support