### PR TITLE
Update almalinux-9-gencloud.pkr.hcl | fix, ansible error - extra arguments at end of line

### DIFF
--- a/almalinux-9-gencloud.pkr.hcl
+++ b/almalinux-9-gencloud.pkr.hcl
@@ -142,10 +142,16 @@ build {
     galaxy_file      = "./ansible/requirements.yml"
     roles_path       = "./ansible/roles"
     collections_path = "./ansible/collections"
+    extra_arguments = [
+      "--ssh-extra-args", "-o ControlMaster=no",
+      "--ssh-extra-args", "-o ControlPersist=180s",
+      "--ssh-extra-args", "-o ServerAliveInterval=120s",
+      "--ssh-extra-args", "-o TCPKeepAlive=yes",
+      "--scp-extra-args", "'-O'"
+    ]
     ansible_env_vars = [
       "ANSIBLE_PIPELINING=True",
-      "ANSIBLE_REMOTE_TEMP=/tmp",
-      "ANSIBLE_SSH_ARGS='-o ControlMaster=no -o ControlPersist=180s -o ServerAliveInterval=120s -o TCPKeepAlive=yes'"
+      "ANSIBLE_REMOTE_TEMP=/tmp"
     ]
   }
 }


### PR DESCRIPTION
Ansible error, example:
```
almalinux-9-gencloud-bios-x86_64: fatal: [default]: UNREACHABLE! => {"changed": false, "msg": "Data could not be sent to remote host \"127.0.0.1\". Make sure this host can be reached over ssh: command-line line 0: keyword controlmaster extra arguments at end of line\r\n", "unreachable": true}
```