### PR TITLE
Fix The post-processor vagrant is unknown

### DIFF
--- a/versions.pkr.hcl
+++ b/versions.pkr.hcl
@@ -1,17 +1,17 @@
 packer {
   required_version = ">= 1.7.0"
   required_plugins {
-    qemu = {
-      version = ">= 1.0.7"
-      source  = "github.com/hashicorp/qemu"
+    amazon = {
+      version = ">= 1.1.0"
+      source  = "github.com/hashicorp/amazon"
     }
-    virtualbox = {
-      version = ">= 1.0.3"
-      source  = "github.com/hashicorp/virtualbox"
+    ansible = {
+      version = ">= 1.1.0"
+      source  = "github.com/hashicorp/ansible"
     }
-    vmware = {
-      version = ">= 1.0.6"
-      source  = "github.com/hashicorp/vmware"
+    digitalocean = {
+      version = ">= 1.2.0"
+      source  = "github.com/digitalocean/digitalocean"
     }
     hyperv = {
       version = ">= 1.0.3"
@@ -21,17 +21,21 @@ packer {
       version = ">= 1.1.2"
       source  = "github.com/Parallels/parallels"
     }
-    ansible = {
-      version = ">= 1.1.0"
-      source  = "github.com/hashicorp/ansible"
+    qemu = {
+      version = ">= 1.0.7"
+      source  = "github.com/hashicorp/qemu"
     }
-    amazon = {
+    vagrant = {
       version = ">= 1.1.0"
-      source  = "github.com/hashicorp/amazon"
+      source  = "github.com/hashicorp/vagrant"
     }
-    digitalocean = {
-      version = ">= 1.2.0"
-      source  = "github.com/digitalocean/digitalocean"
+    virtualbox = {
+      version = ">= 1.0.3"
+      source  = "github.com/hashicorp/virtualbox"
+    }
+    vmware = {
+      version = ">= 1.0.6"
+      source  = "github.com/hashicorp/vmware"
     }
   }
 }


### PR DESCRIPTION
Since vagrant is not included in Packer anymore and available as an external plugin, define it in versions.pkr.hcl as we did for other external plugins.
This fixes "The post-processor vagrant is unknown by Packer" error on "packer init".