### PR TITLE
Update kernel options

### DIFF
--- a/http/almalinux-8.azure-x86_64.ks
+++ b/http/almalinux-8.azure-x86_64.ks
@@ -20,7 +20,8 @@ firewall --disabled
 services --disabled="kdump" --enabled="chronyd,rsyslog,sshd"
 selinux --enforcing
 
-bootloader --append="console=tty1 console=ttyS0,115200n8 earlyprintk=ttyS0,115200 rootdelay=300 net.ifnames=0" --location=mbr --timeout=1
+bootloader --timeout=0 --location=mbr --append="loglevel=3 console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300 no_timer_check net.ifnames=0"
+
 zerombr
 bootloader --location=mbr --timeout=1
 part /boot/efi --onpart=sda15 --fstype=vfat

--- a/http/almalinux-8.gencloud-aarch64.ks
+++ b/http/almalinux-8.gencloud-aarch64.ks
@@ -18,8 +18,8 @@ firewall --enabled --service=ssh
 services --disabled="kdump" --enabled="chronyd,rsyslog,sshd"
 selinux --enforcing
 
-# TODO: remove "console=tty0" from here
-bootloader --append="console=ttyS0,115200n8 console=tty0 crashkernel=auto net.ifnames=0 no_timer_check" --location=mbr --timeout=1
+bootloader --timeout=0 --location=mbr --append="console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0"
+
 zerombr
 clearpart --all --initlabel
 reqpart

--- a/http/almalinux-8.gencloud-ppc64le.ks
+++ b/http/almalinux-8.gencloud-ppc64le.ks
@@ -18,8 +18,8 @@ firewall --enabled --service=ssh
 services --disabled="kdump" --enabled="chronyd,rsyslog,sshd"
 selinux --enforcing
 
-# TODO: remove "console=tty0" from here
-bootloader --append="console=ttyS0,115200n8 console=tty0 crashkernel=auto net.ifnames=0 no_timer_check" --location=mbr --timeout=1
+bootloader --timeout=0 --location=mbr --append="console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0"
+
 zerombr
 clearpart --all --initlabel
 reqpart

--- a/http/almalinux-8.gencloud-x86_64.ks
+++ b/http/almalinux-8.gencloud-x86_64.ks
@@ -18,8 +18,8 @@ firewall --enabled --service=ssh
 services --disabled="kdump" --enabled="chronyd,rsyslog,sshd"
 selinux --enforcing
 
-# TODO: remove "console=tty0" from here
-bootloader --append="console=ttyS0,115200n8 console=tty0 crashkernel=auto net.ifnames=0 no_timer_check" --location=mbr --timeout=1
+bootloader --timeout=0 --location=mbr --append="console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0"
+
 zerombr
 clearpart --all --initlabel
 reqpart

--- a/http/almalinux-8.opennebula-aarch64.ks
+++ b/http/almalinux-8.opennebula-aarch64.ks
@@ -18,8 +18,8 @@ firewall --enabled --service=ssh
 services --disabled="kdump" --enabled="chronyd,rsyslog,sshd"
 selinux --enforcing
 
-# TODO: remove "console=tty0" from here
-bootloader --append="console=ttyS0,115200n8 console=tty0 crashkernel=auto net.ifnames=0 no_timer_check" --location=mbr --timeout=1
+bootloader --timeout=0 --location=mbr --append="console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0"
+
 zerombr
 clearpart --all --initlabel
 reqpart

--- a/http/almalinux-8.opennebula-x86_64.ks
+++ b/http/almalinux-8.opennebula-x86_64.ks
@@ -18,8 +18,8 @@ firewall --enabled --service=ssh
 services --disabled="kdump" --enabled="chronyd,rsyslog,sshd"
 selinux --enforcing
 
-# TODO: remove "console=tty0" from here
-bootloader --append="console=ttyS0,115200n8 console=tty0 crashkernel=auto net.ifnames=0 no_timer_check" --location=mbr --timeout=1
+bootloader --timeout=0 --location=mbr --append="console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0"
+
 zerombr
 clearpart --all --initlabel
 reqpart

--- a/http/almalinux-8.vagrant.ks
+++ b/http/almalinux-8.vagrant.ks
@@ -19,7 +19,8 @@ firewall --disabled
 services --enabled=sshd
 selinux --enforcing
 
-bootloader --location=mbr
+bootloader --timeout=0 --location=mbr --append="console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0"
+
 zerombr
 clearpart --all --initlabel
 autopart --type=plain --nohome --noboot --noswap

--- a/http/almalinux-9.azure-x86_64.ks
+++ b/http/almalinux-9.azure-x86_64.ks
@@ -18,7 +18,7 @@ firewall --enabled --service=ssh
 services --disabled="kdump" --enabled="chronyd,rsyslog,sshd"
 selinux --enforcing
 
-bootloader --timeout=1 --location=mbr --append="console=tty0 console=ttyS0,115200n8 no_timer_check crashkernel=auto net.ifnames=0"
+bootloader --timeout=0 --location=mbr --append="loglevel=3 console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300 no_timer_check net.ifnames=0"
 
 %pre --erroronfail
 

--- a/http/almalinux-9.gencloud-aarch64.ks
+++ b/http/almalinux-9.gencloud-aarch64.ks
@@ -18,7 +18,7 @@ firewall --enabled --service=ssh
 services --disabled="kdump" --enabled="chronyd,rsyslog,sshd"
 selinux --enforcing
 
-bootloader --timeout=1 --location=mbr --append="console=tty0 console=ttyS0,115200n8 no_timer_check crashkernel=auto net.ifnames=0"
+bootloader --timeout=0 --location=mbr --append="console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0"
 
 zerombr
 clearpart --all --initlabel

--- a/http/almalinux-9.gencloud-ppc64le.ks
+++ b/http/almalinux-9.gencloud-ppc64le.ks
@@ -18,7 +18,7 @@ firewall --enabled --service=ssh
 services --disabled="kdump" --enabled="chronyd,rsyslog,sshd"
 selinux --enforcing
 
-bootloader --timeout=1 --location=mbr --append="console=tty0 console=ttyS0,115200n8 no_timer_check crashkernel=auto net.ifnames=0"
+bootloader --timeout=0 --location=mbr --append="console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0"
 
 zerombr
 clearpart --all --initlabel

--- a/http/almalinux-9.gencloud-x86_64-bios.ks
+++ b/http/almalinux-9.gencloud-x86_64-bios.ks
@@ -18,7 +18,8 @@ firewall --enabled --service=ssh
 services --disabled="kdump" --enabled="chronyd,rsyslog,sshd"
 selinux --enforcing
 
-bootloader --timeout=1 --location=mbr --append="console=ttyS0,115200n8 no_timer_check crashkernel=auto net.ifnames=0"
+bootloader --timeout=0 --location=mbr --append="console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0"
+
 zerombr
 clearpart --all --initlabel
 reqpart

--- a/http/almalinux-9.gencloud-x86_64.ks
+++ b/http/almalinux-9.gencloud-x86_64.ks
@@ -18,7 +18,7 @@ firewall --enabled --service=ssh
 services --disabled="kdump" --enabled="chronyd,rsyslog,sshd"
 selinux --enforcing
 
-bootloader --timeout=1 --location=mbr --append="console=tty0 console=ttyS0,115200n8 no_timer_check crashkernel=auto net.ifnames=0"
+bootloader --timeout=0 --location=mbr --append="console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0"
 
 %pre --erroronfail
 

--- a/http/almalinux-9.vagrant-aarch64.ks
+++ b/http/almalinux-9.vagrant-aarch64.ks
@@ -18,7 +18,8 @@ firewall --disabled
 services --enabled=sshd
 selinux --enforcing
 
-bootloader --location=mbr
+bootloader --timeout=0 --location=mbr --append="console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0"
+
 zerombr
 clearpart --all --initlabel
 autopart --type=plain --nohome --noboot --noswap

--- a/http/almalinux-9.vagrant-x86_64.ks
+++ b/http/almalinux-9.vagrant-x86_64.ks
@@ -18,7 +18,7 @@ firewall --disabled
 services --enabled=sshd
 selinux --enforcing
 
-bootloader --location=mbr
+bootloader --timeout=0 --location=mbr --append="console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0"
 
 %pre --erroronfail
 


### PR DESCRIPTION
- Set default timeout of GRUB2 from 1 to 0.
- Remove crashkernel option since kdump is disabled.
- Update kernel options for Azure.