### PR TITLE
Refactor options of Ansible Packer provisioner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ venv
 
 # Editors
 .idea
+.vscode

--- a/almalinux-8-azure.pkr.hcl
+++ b/almalinux-8-azure.pkr.hcl
@@ -37,14 +37,15 @@ build {
   sources = ["qemu.almalinux-8-azure-x86_64"]
 
   provisioner "ansible" {
-    playbook_file    = "./ansible/azure.yml"
-    galaxy_file      = "./ansible/requirements.yml"
-    roles_path       = "./ansible/roles"
-    collections_path = "./ansible/collections"
+    galaxy_file          = "./ansible/requirements.yml"
+    galaxy_force_install = true
+    collections_path     = "./ansible/collections"
+    roles_path           = "./ansible/roles"
+    playbook_file        = "./ansible/azure.yml"
     ansible_env_vars = [
       "ANSIBLE_PIPELINING=True",
       "ANSIBLE_REMOTE_TEMP=/tmp",
-      "ANSIBLE_SSH_ARGS='-o ControlMaster=no -o ControlPersist=180s -o ServerAliveInterval=120s -o TCPKeepAlive=yes'"
+      "ANSIBLE_SCP_EXTRA_ARGS=-O"
     ]
   }
 }

--- a/almalinux-8-digitalocean.pkr.hcl
+++ b/almalinux-8-digitalocean.pkr.hcl
@@ -33,14 +33,15 @@ build {
   sources = ["qemu.almalinux-8-digitalocean-x86_64"]
 
   provisioner "ansible" {
-    playbook_file    = "./ansible/digitalocean.yml"
-    galaxy_file      = "./ansible/requirements.yml"
-    roles_path       = "./ansible/roles"
-    collections_path = "./ansible/collections"
+    galaxy_file          = "./ansible/requirements.yml"
+    galaxy_force_install = true
+    collections_path     = "./ansible/collections"
+    roles_path           = "./ansible/roles"
+    playbook_file        = "./ansible/digitalocean.yml"
     ansible_env_vars = [
       "ANSIBLE_PIPELINING=True",
       "ANSIBLE_REMOTE_TEMP=/tmp",
-      "ANSIBLE_SSH_ARGS='-o ControlMaster=no -o ControlPersist=180s -o ServerAliveInterval=120s -o TCPKeepAlive=yes'"
+      "ANSIBLE_SCP_EXTRA_ARGS=-O"
     ]
   }
 

--- a/almalinux-8-gencloud.pkr.hcl
+++ b/almalinux-8-gencloud.pkr.hcl
@@ -131,14 +131,15 @@ build {
   ]
 
   provisioner "ansible" {
-    playbook_file    = "./ansible/gencloud.yml"
-    galaxy_file      = "./ansible/requirements.yml"
-    roles_path       = "./ansible/roles"
-    collections_path = "./ansible/collections"
+    galaxy_file          = "./ansible/requirements.yml"
+    galaxy_force_install = true
+    collections_path     = "./ansible/collections"
+    roles_path           = "./ansible/roles"
+    playbook_file        = "./ansible/gencloud.yml"
     ansible_env_vars = [
       "ANSIBLE_PIPELINING=True",
       "ANSIBLE_REMOTE_TEMP=/tmp",
-      "ANSIBLE_SSH_ARGS='-o ControlMaster=no -o ControlPersist=180s -o ServerAliveInterval=120s -o TCPKeepAlive=yes'"
+      "ANSIBLE_SCP_EXTRA_ARGS=-O"
     ]
   }
 }

--- a/almalinux-8-oci.pkr.hcl
+++ b/almalinux-8-oci.pkr.hcl
@@ -102,14 +102,15 @@ build {
   ]
 
   provisioner "ansible" {
-    playbook_file    = "./ansible/oci.yml"
-    galaxy_file      = "./ansible/requirements.yml"
-    roles_path       = "./ansible/roles"
-    collections_path = "./ansible/collections"
+    galaxy_file          = "./ansible/requirements.yml"
+    galaxy_force_install = true
+    collections_path     = "./ansible/collections"
+    roles_path           = "./ansible/roles"
+    playbook_file        = "./ansible/oci.yml"
     ansible_env_vars = [
       "ANSIBLE_PIPELINING=True",
       "ANSIBLE_REMOTE_TEMP=/tmp",
-      "ANSIBLE_SSH_ARGS='-o ControlMaster=no -o ControlPersist=180s -o ServerAliveInterval=120s -o TCPKeepAlive=yes'"
+      "ANSIBLE_SCP_EXTRA_ARGS=-O"
     ]
   }
 }

--- a/almalinux-8-opennebula.pkr.hcl
+++ b/almalinux-8-opennebula.pkr.hcl
@@ -71,14 +71,15 @@ build {
   ]
 
   provisioner "ansible" {
-    playbook_file    = "./ansible/opennebula.yml"
-    galaxy_file      = "./ansible/requirements.yml"
-    roles_path       = "./ansible/roles"
-    collections_path = "./ansible/collections"
+    galaxy_file          = "./ansible/requirements.yml"
+    galaxy_force_install = true
+    collections_path     = "./ansible/collections"
+    roles_path           = "./ansible/roles"
+    playbook_file        = "./ansible/opennebula.yml"
     ansible_env_vars = [
       "ANSIBLE_PIPELINING=True",
       "ANSIBLE_REMOTE_TEMP=/tmp",
-      "ANSIBLE_SSH_ARGS='-o ControlMaster=no -o ControlPersist=180s -o ServerAliveInterval=120s -o TCPKeepAlive=yes'"
+      "ANSIBLE_SCP_EXTRA_ARGS=-O"
     ]
   }
 }

--- a/almalinux-8-vagrant.pkr.hcl
+++ b/almalinux-8-vagrant.pkr.hcl
@@ -163,14 +163,15 @@ build {
   ]
 
   provisioner "ansible" {
-    playbook_file    = "./ansible/vagrant-box.yml"
-    galaxy_file      = "./ansible/requirements.yml"
-    roles_path       = "./ansible/roles"
-    collections_path = "./ansible/collections"
+    galaxy_file          = "./ansible/requirements.yml"
+    galaxy_force_install = true
+    collections_path     = "./ansible/collections"
+    roles_path           = "./ansible/roles"
+    playbook_file        = "./ansible/vagrant-box.yml"
     ansible_env_vars = [
       "ANSIBLE_PIPELINING=True",
       "ANSIBLE_REMOTE_TEMP=/tmp",
-      "ANSIBLE_SSH_ARGS='-o ControlMaster=no -o ControlPersist=180s -o ServerAliveInterval=120s -o TCPKeepAlive=yes'"
+      "ANSIBLE_SCP_EXTRA_ARGS=-O"
     ]
     extra_arguments = [
       "--extra-vars",
@@ -182,16 +183,17 @@ build {
   }
 
   provisioner "ansible" {
-    user             = "vagrant"
-    use_proxy        = false
-    playbook_file    = "./ansible/vagrant-box.yml"
-    galaxy_file      = "./ansible/requirements.yml"
-    roles_path       = "./ansible/roles"
-    collections_path = "./ansible/collections"
+    user                 = "vagrant"
+    use_proxy            = false
+    galaxy_file          = "./ansible/requirements.yml"
+    galaxy_force_install = true
+    collections_path     = "./ansible/collections"
+    roles_path           = "./ansible/roles"
+    playbook_file        = "./ansible/vagrant-box.yml"
     ansible_env_vars = [
       "ANSIBLE_PIPELINING=True",
       "ANSIBLE_REMOTE_TEMP=/tmp",
-      "ANSIBLE_SSH_ARGS='-o ControlMaster=no -o ControlPersist=180s -o ServerAliveInterval=120s -o TCPKeepAlive=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'"
+      "ANSIBLE_SCP_EXTRA_ARGS=-O"
     ]
     extra_arguments = [
       "--extra-vars",

--- a/almalinux-9-azure.pkr.hcl
+++ b/almalinux-9-azure.pkr.hcl
@@ -37,14 +37,15 @@ build {
   sources = ["qemu.almalinux-9-azure-x86_64"]
 
   provisioner "ansible" {
-    playbook_file    = "./ansible/azure.yml"
-    galaxy_file      = "./ansible/requirements.yml"
-    roles_path       = "./ansible/roles"
-    collections_path = "./ansible/collections"
+    galaxy_file          = "./ansible/requirements.yml"
+    galaxy_force_install = true
+    collections_path     = "./ansible/collections"
+    roles_path           = "./ansible/roles"
+    playbook_file        = "./ansible/azure.yml"
     ansible_env_vars = [
       "ANSIBLE_PIPELINING=True",
       "ANSIBLE_REMOTE_TEMP=/tmp",
-      "ANSIBLE_SSH_ARGS='-o ControlMaster=no -o ControlPersist=180s -o ServerAliveInterval=120s -o TCPKeepAlive=yes'"
+      "ANSIBLE_SCP_EXTRA_ARGS=-O"
     ]
   }
 }

--- a/almalinux-9-digitalocean.pkr.hcl
+++ b/almalinux-9-digitalocean.pkr.hcl
@@ -37,14 +37,15 @@ build {
   sources = ["qemu.almalinux-9-digitalocean-x86_64"]
 
   provisioner "ansible" {
-    playbook_file    = "./ansible/digitalocean.yml"
-    galaxy_file      = "./ansible/requirements.yml"
-    roles_path       = "./ansible/roles"
-    collections_path = "./ansible/collections"
+    galaxy_file          = "./ansible/requirements.yml"
+    galaxy_force_install = true
+    collections_path     = "./ansible/collections"
+    roles_path           = "./ansible/roles"
+    playbook_file        = "./ansible/digitalocean.yml"
     ansible_env_vars = [
       "ANSIBLE_PIPELINING=True",
       "ANSIBLE_REMOTE_TEMP=/tmp",
-      "ANSIBLE_SSH_ARGS='-o ControlMaster=no -o ControlPersist=180s -o ServerAliveInterval=120s -o TCPKeepAlive=yes'"
+      "ANSIBLE_SCP_EXTRA_ARGS=-O"
     ]
   }
 

--- a/almalinux-9-gencloud.pkr.hcl
+++ b/almalinux-9-gencloud.pkr.hcl
@@ -138,14 +138,15 @@ build {
   ]
 
   provisioner "ansible" {
-    playbook_file    = "./ansible/gencloud.yml"
-    galaxy_file      = "./ansible/requirements.yml"
-    roles_path       = "./ansible/roles"
-    collections_path = "./ansible/collections"
+    galaxy_file          = "./ansible/requirements.yml"
+    galaxy_force_install = true
+    collections_path     = "./ansible/collections"
+    roles_path           = "./ansible/roles"
+    playbook_file        = "./ansible/gencloud.yml"
     ansible_env_vars = [
       "ANSIBLE_PIPELINING=True",
       "ANSIBLE_REMOTE_TEMP=/tmp",
-      "ANSIBLE_SSH_ARGS='-o ControlMaster=no -o ControlPersist=180s -o ServerAliveInterval=120s -o TCPKeepAlive=yes'"
+      "ANSIBLE_SCP_EXTRA_ARGS=-O"
     ]
   }
 }

--- a/almalinux-9-oci.pkr.hcl
+++ b/almalinux-9-oci.pkr.hcl
@@ -109,14 +109,15 @@ build {
   ]
 
   provisioner "ansible" {
-    playbook_file    = "./ansible/oci.yml"
-    galaxy_file      = "./ansible/requirements.yml"
-    roles_path       = "./ansible/roles"
-    collections_path = "./ansible/collections"
+    galaxy_file          = "./ansible/requirements.yml"
+    galaxy_force_install = true
+    collections_path     = "./ansible/collections"
+    roles_path           = "./ansible/roles"
+    playbook_file        = "./ansible/oci.yml"
     ansible_env_vars = [
       "ANSIBLE_PIPELINING=True",
       "ANSIBLE_REMOTE_TEMP=/tmp",
-      "ANSIBLE_SSH_ARGS='-o ControlMaster=no -o ControlPersist=180s -o ServerAliveInterval=120s -o TCPKeepAlive=yes'"
+      "ANSIBLE_SCP_EXTRA_ARGS=-O"
     ]
   }
 }

--- a/almalinux-9-opennebula.pkr.hcl
+++ b/almalinux-9-opennebula.pkr.hcl
@@ -109,14 +109,15 @@ build {
   ]
 
   provisioner "ansible" {
-    playbook_file    = "./ansible/opennebula.yml"
-    galaxy_file      = "./ansible/requirements.yml"
-    roles_path       = "./ansible/roles"
-    collections_path = "./ansible/collections"
+    galaxy_file          = "./ansible/requirements.yml"
+    galaxy_force_install = true
+    collections_path     = "./ansible/collections"
+    roles_path           = "./ansible/roles"
+    playbook_file        = "./ansible/opennebula.yml"
     ansible_env_vars = [
       "ANSIBLE_PIPELINING=True",
       "ANSIBLE_REMOTE_TEMP=/tmp",
-      "ANSIBLE_SSH_ARGS='-o ControlMaster=no -o ControlPersist=180s -o ServerAliveInterval=120s -o TCPKeepAlive=yes'"
+      "ANSIBLE_SCP_EXTRA_ARGS=-O"
     ]
   }
 }

--- a/almalinux-9-vagrant.pkr.hcl
+++ b/almalinux-9-vagrant.pkr.hcl
@@ -209,14 +209,15 @@ build {
   ]
 
   provisioner "ansible" {
-    playbook_file    = "./ansible/vagrant-box.yml"
-    galaxy_file      = "./ansible/requirements.yml"
-    roles_path       = "./ansible/roles"
-    collections_path = "./ansible/collections"
+    galaxy_file          = "./ansible/requirements.yml"
+    galaxy_force_install = true
+    collections_path     = "./ansible/collections"
+    roles_path           = "./ansible/roles"
+    playbook_file        = "./ansible/vagrant-box.yml"
     ansible_env_vars = [
       "ANSIBLE_PIPELINING=True",
       "ANSIBLE_REMOTE_TEMP=/tmp",
-      "ANSIBLE_SSH_ARGS='-o ControlMaster=no -o ControlPersist=180s -o ServerAliveInterval=120s -o TCPKeepAlive=yes'"
+      "ANSIBLE_SCP_EXTRA_ARGS=-O"
     ]
     extra_arguments = [
       "--extra-vars",
@@ -228,16 +229,17 @@ build {
   }
 
   provisioner "ansible" {
-    user             = "vagrant"
-    use_proxy        = false
-    playbook_file    = "./ansible/vagrant-box.yml"
-    galaxy_file      = "./ansible/requirements.yml"
-    roles_path       = "./ansible/roles"
-    collections_path = "./ansible/collections"
+    user                 = "vagrant"
+    use_proxy            = false
+    galaxy_file          = "./ansible/requirements.yml"
+    galaxy_force_install = true
+    collections_path     = "./ansible/collections"
+    roles_path           = "./ansible/roles"
+    playbook_file        = "./ansible/vagrant-box.yml"
     ansible_env_vars = [
       "ANSIBLE_PIPELINING=True",
       "ANSIBLE_REMOTE_TEMP=/tmp",
-      "ANSIBLE_SSH_ARGS='-o ControlMaster=no -o ControlPersist=180s -o ServerAliveInterval=120s -o TCPKeepAlive=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'"
+      "ANSIBLE_SCP_EXTRA_ARGS=-O"
     ]
     extra_arguments = [
       "--extra-vars",


### PR DESCRIPTION
- Remove ANSIBLE_SSH_ARGS Ansible works just fine without it and never seen any advantage of using it. It also breaks building of Vagrant boxes for Parallels and VMware Fusion on macOS.

- Use -O flag of scp by default Previously, We had to maintain two separate git branches with and without of it to directly build images without commenting/uncommenting this option each time.
Since all supported versions of major Linux distros already either had newer OpenSSH than 8.9/8.9p1 or backported this feature.
It's good time to have a single branch and add a instruction how to mass disable this option
with single sed command on distros where this flag is not supported.

- Add galaxy_force_install = true to make sure always pull the latest Ansible collections and roles from the requirements.yml file

- Add .vscode directory gitignore. Ansible extension creates it to record python virtual enviroment information.

- Minimalize the README a little bit.