### PR TITLE
Fix and enhancements for AMIs

### DIFF
--- a/ansible/roles/ami_8_aarch64/defaults/main.yaml
+++ b/ansible/roles/ami_8_aarch64/defaults/main.yaml
@@ -1,2 +1,2 @@
 ---
-ami_8_aarch64_kernel_opts: console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 iommu.strict=0
+ami_8_aarch64_kernel_opts: console=tty0 console=ttyS0,115200n8 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 iommu.strict=0

--- a/ansible/roles/ami_8_aarch64/tasks/bootloader.yaml
+++ b/ansible/roles/ami_8_aarch64/tasks/bootloader.yaml
@@ -35,7 +35,11 @@
 
 - name: Generate new GRUB environment block
   ansible.builtin.command:
-    cmd: chroot /rootfs grub2-editenv -v /boot/efi/EFI/almalinux/grubenv set saved_entry=ffffffffffffffffffffffffffffffff-{{ kernel_ver.stdout }}
+    cmd: >
+      chroot /rootfs grub2-editenv -v /boot/efi/EFI/almalinux/grubenv set
+      kernelopts="root=UUID={{ root_uuid.stdout }}
+      {{ ami_8_aarch64_kernel_opts }}"
+      saved_entry=ffffffffffffffffffffffffffffffff-{{ kernel_ver.stdout }}
     creates: /rootfs/boot/efi/EFI/almalinux/grubenv
 
 # # Gives "ok" as status and doesn't modify the file permissions

--- a/ansible/roles/ami_8_x86_64/defaults/main.yaml
+++ b/ansible/roles/ami_8_x86_64/defaults/main.yaml
@@ -1,2 +1,2 @@
 ---
-ami_8_x86_64_kernel_opts: console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295
+ami_8_x86_64_kernel_opts: console=tty0 console=ttyS0,115200n8 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295

--- a/ansible/roles/ami_8_x86_64/tasks/bootloader.yaml
+++ b/ansible/roles/ami_8_x86_64/tasks/bootloader.yaml
@@ -56,7 +56,11 @@
 
 - name: Generate new GRUB environment block
   ansible.builtin.command:
-    cmd: chroot /rootfs grub2-editenv -v - set saved_entry=ffffffffffffffffffffffffffffffff-{{ kernel_ver.stdout }}
+    cmd: >
+      chroot /rootfs grub2-editenv -v - set
+      kernelopts="root=UUID={{ root_uuid.stdout }}
+      {{ ami_8_x86_64_kernel_opts }}"
+      saved_entry=ffffffffffffffffffffffffffffffff-{{ kernel_ver.stdout }}
     creates: /rootfs/boot/grub2/grubenv
 
 - name: Set permissions of GRUB environment block

--- a/ansible/roles/ami_9_aarch64/defaults/main.yaml
+++ b/ansible/roles/ami_9_aarch64/defaults/main.yaml
@@ -1,2 +1,2 @@
 ---
-ami_9_aarch64_kernel_opts: console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 iommu.strict=0
+ami_9_aarch64_kernel_opts: console=tty0 console=ttyS0,115200n8 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295 iommu.strict=0

--- a/ansible/roles/ami_9_aarch64/tasks/bootloader.yaml
+++ b/ansible/roles/ami_9_aarch64/tasks/bootloader.yaml
@@ -35,7 +35,9 @@
 
 - name: Generate new GRUB environment block
   ansible.builtin.command:
-    cmd: chroot /rootfs grub2-editenv -v - set saved_entry=ffffffffffffffffffffffffffffffff-{{ kernel_ver.stdout }}
+    cmd: >
+      chroot /rootfs grub2-editenv -v - set
+      saved_entry=ffffffffffffffffffffffffffffffff-{{ kernel_ver.stdout }}
     creates: /rootfs/boot/grub2/grubenv
 
 - name: Set permissions of GRUB environment block

--- a/ansible/roles/ami_9_x86_64/defaults/main.yaml
+++ b/ansible/roles/ami_9_x86_64/defaults/main.yaml
@@ -1,2 +1,2 @@
 ---
-ami_9_x86_64_kernel_opts: console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295
+ami_9_x86_64_kernel_opts: console=tty0 console=ttyS0,115200n8 net.ifnames=0 rd.blacklist=nouveau nvme_core.io_timeout=4294967295

--- a/ansible/roles/ami_9_x86_64/tasks/bootloader.yaml
+++ b/ansible/roles/ami_9_x86_64/tasks/bootloader.yaml
@@ -40,7 +40,9 @@
 
 - name: Generate new GRUB environment block
   ansible.builtin.command:
-    cmd: chroot /rootfs grub2-editenv -v - set saved_entry=ffffffffffffffffffffffffffffffff-{{ kernel_ver.stdout }}
+    cmd: >
+      chroot /rootfs grub2-editenv -v - set
+      saved_entry=ffffffffffffffffffffffffffffffff-{{ kernel_ver.stdout }}
     creates: /rootfs/boot/grub2/grubenv
 
 - name: Set permissions of GRUB environment block

--- a/tests/test-values.pkrvars.hcl
+++ b/tests/test-values.pkrvars.hcl
@@ -1,6 +1,3 @@
-# AWS
-aws_s3_bucket_name = "foo"
-
 # DigitalOcean
 do_api_token = "foo"
 do_spaces_key = "foo"


### PR DESCRIPTION
- Fixes for AlmaLinux OS 8 On AlmaLinux OS 8, The UUID of root partition should be set in GRUB environment block to make the boot process work on UEFI.

- Set serial as a primary console We tried to make kernel options compatible with
RHEL Amazon Machine Images. However, the order of the console devices is not consistent between the builds and major versions: "console=ttyS0,115200n8 console=tty0" vs
"console=tty0 console=ttyS0,115200n8".
Since the last defined console is the primary, which means it used also by systemd to print init logs in addition the kernel logs.

Let's set "console=ttyS0,115200n8" as a primary,
as the last console to print the whole output (kernel and init) to EC2 serial console.

This should aid troubleshooting/debugging experience of boot process.