### PR TITLE
Reduce output of file deleting tasks

### DIFF
--- a/ansible/roles/ami_8_aarch64/tasks/guest.yaml
+++ b/ansible/roles/ami_8_aarch64/tasks/guest.yaml
@@ -30,6 +30,8 @@
     path: "{{ item.path }}"
     state: absent
   loop: "{{ net_rules.files }}"
+  loop_control:
+    label: "{{ item.path }}"
 
 - name: Configure /etc/sysconfig/network
   ansible.builtin.lineinfile:

--- a/ansible/roles/ami_8_x86_64/tasks/cleanup.yaml
+++ b/ansible/roles/ami_8_x86_64/tasks/cleanup.yaml
@@ -19,6 +19,8 @@
     path: "{{ item.path }}"
     state: absent
   loop: "{{ dnf_cache.files }}"
+  loop_control:
+    label: "{{ item.path }}"
 
 - name: Find DNF history files
   ansible.builtin.find:
@@ -31,6 +33,8 @@
     path: "{{ item.path }}"
     state: absent
   loop: "{{ dnf_history.files }}"
+  loop_control:
+    label: "{{ item.path }}"
 
 - name: Find temporary files
   ansible.builtin.find:
@@ -46,6 +50,8 @@
     path: "{{ item.path }}"
     state: absent
   loop: "{{ tmp_files.files }}"
+  loop_control:
+    label: "{{ item.path }}"
 
 - name: Truncate files
   ansible.builtin.command: truncate -s 0 {{ item }}
@@ -87,6 +93,8 @@
     path: "{{ item.path }}"
     state: absent
   loop: "{{ log_files.files }}"
+  loop_control:
+    label: "{{ item.path }}"
 
 - name: Remove random-seed
   ansible.builtin.file:

--- a/ansible/roles/ami_8_x86_64/tasks/guest.yaml
+++ b/ansible/roles/ami_8_x86_64/tasks/guest.yaml
@@ -30,6 +30,8 @@
     path: "{{ item.path }}"
     state: absent
   loop: "{{ net_rules.files }}"
+  loop_control:
+    label: "{{ item.path }}"
 
 - name: Configure /etc/sysconfig/network
   ansible.builtin.lineinfile:

--- a/ansible/roles/ami_9_aarch64/tasks/cleanup.yaml
+++ b/ansible/roles/ami_9_aarch64/tasks/cleanup.yaml
@@ -19,6 +19,8 @@
     path: "{{ item.path }}"
     state: absent
   loop: "{{ dnf_cache.files }}"
+  loop_control:
+    label: "{{ item.path }}"
 
 - name: Find DNF history files
   ansible.builtin.find:
@@ -31,6 +33,8 @@
     path: "{{ item.path }}"
     state: absent
   loop: "{{ dnf_history.files }}"
+  loop_control:
+    label: "{{ item.path }}"
 
 - name: Find temporary files
   ansible.builtin.find:
@@ -46,6 +50,8 @@
     path: "{{ item.path }}"
     state: absent
   loop: "{{ tmp_files.files }}"
+  loop_control:
+    label: "{{ item.path }}"
 
 - name: Truncate files
   ansible.builtin.command: truncate -s 0 {{ item }}
@@ -87,6 +93,8 @@
     path: "{{ item.path }}"
     state: absent
   loop: "{{ log_files.files }}"
+  loop_control:
+    label: "{{ item.path }}"
 
 - name: Remove random-seed
   ansible.builtin.file:

--- a/ansible/roles/ami_9_aarch64/tasks/guest.yaml
+++ b/ansible/roles/ami_9_aarch64/tasks/guest.yaml
@@ -30,6 +30,8 @@
     path: "{{ item.path }}"
     state: absent
   loop: "{{ net_rules.files }}"
+  loop_control:
+    label: "{{ item.path }}"
 
 - name: Configure /etc/sysconfig/network
   ansible.builtin.lineinfile:

--- a/ansible/roles/ami_9_x86_64/tasks/cleanup.yaml
+++ b/ansible/roles/ami_9_x86_64/tasks/cleanup.yaml
@@ -19,6 +19,8 @@
     path: "{{ item.path }}"
     state: absent
   loop: "{{ dnf_cache.files }}"
+  loop_control:
+    label: "{{ item.path }}"
 
 - name: Find DNF history files
   ansible.builtin.find:
@@ -31,6 +33,8 @@
     path: "{{ item.path }}"
     state: absent
   loop: "{{ dnf_history.files }}"
+  loop_control:
+    label: "{{ item.path }}"
 
 - name: Find temporary files
   ansible.builtin.find:
@@ -46,6 +50,8 @@
     path: "{{ item.path }}"
     state: absent
   loop: "{{ tmp_files.files }}"
+  loop_control:
+    label: "{{ item.path }}"
 
 - name: Truncate files
   ansible.builtin.command: truncate -s 0 {{ item }}
@@ -87,6 +93,8 @@
     path: "{{ item.path }}"
     state: absent
   loop: "{{ log_files.files }}"
+  loop_control:
+    label: "{{ item.path }}"
 
 - name: Remove random-seed
   ansible.builtin.file:

--- a/ansible/roles/cleanup_vm/tasks/main.yml
+++ b/ansible/roles/cleanup_vm/tasks/main.yml
@@ -16,6 +16,8 @@
     path: "{{ item.path }}"
     state: absent
   loop: "{{ dnf_history.files }}"
+  loop_control:
+    label: "{{ item.path }}"
 
 - name: Find temporary files
   find:
@@ -31,6 +33,8 @@
     path: "{{ item.path }}"
     state: absent
   loop: "{{ tmp_files.files }}"
+  loop_control:
+    label: "{{ item.path }}"
 
 - name: Remove SSH host keys
   block:
@@ -45,6 +49,8 @@
         path: "{{ item.path }}"
         state: absent
       loop: "{{ host_keys.files }}"
+      loop_control:
+        label: "{{ item.path }}"
   when: cleanup_ssh_host_keys | bool
 
 - name: Remove kickstart files
@@ -96,6 +102,8 @@
     path: "{{ item.path }}"
     state: absent
   loop: "{{ log_files.files }}"
+  loop_control:
+    label: "{{ item.path }}"
 
 - name: Remove random-seed
   file:


### PR DESCRIPTION
There are number of ansible tasks which are implementing file deletions:
```
./ansible/roles/ami_8_x86_64/tasks/guest.yaml: Delete persistent-net.rules
./ansible/roles/ami_8_x86_64/tasks/cleanup.yaml: Delete DNF leftovers
./ansible/roles/ami_8_x86_64/tasks/cleanup.yaml: Reset DNF history
./ansible/roles/ami_8_x86_64/tasks/cleanup.yaml: Remove temporary files
./ansible/roles/ami_8_x86_64/tasks/cleanup.yaml: Remove log files
./ansible/roles/ami_9_aarch64/tasks/guest.yaml: Delete persistent-net.rules
./ansible/roles/ami_9_aarch64/tasks/cleanup.yaml: Delete DNF leftovers
./ansible/roles/ami_9_aarch64/tasks/cleanup.yaml: Reset DNF history
./ansible/roles/ami_9_aarch64/tasks/cleanup.yaml: Remove temporary files
./ansible/roles/ami_9_aarch64/tasks/cleanup.yaml: Remove log files
./ansible/roles/ami_8_aarch64/tasks/guest.yaml: Delete persistent-net.rules
./ansible/roles/ami_9_x86_64/tasks/cleanup.yaml: Delete DNF leftovers
./ansible/roles/ami_9_x86_64/tasks/cleanup.yaml: Reset DNF history
./ansible/roles/ami_9_x86_64/tasks/cleanup.yaml: Remove temporary files
./ansible/roles/ami_9_x86_64/tasks/cleanup.yaml: Remove log files
./ansible/roles/cleanup_vm/tasks/main.yml: Reset DNF history
./ansible/roles/cleanup_vm/tasks/main.yml: Remove temporary files
./ansible/roles/cleanup_vm/tasks/main.yml: Remove SSH host keys
./ansible/roles/cleanup_vm/tasks/main.yml: Remove log files
```

The tasks provides such kind of output, as example:
```
    qemu.almalinux-9-gencloud-bios-x86_64: TASK [cleanup_vm : Remove log files] *******************************************
    qemu.almalinux-9-gencloud-bios-x86_64: changed: [default] => (item={'path': '/var/log/maillog', 'mode': '0600', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 0, 'inode': 652897, 'dev': 2050, 'nlink': 1, 'atime': 1720432081.3953848, 'mtime': 1720432355.044179, 'ctime': 1720432355.044179, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': False, 'xgrp': False, 'woth': False, 'roth': False, 'xoth': False, 'isuid': False, 'isgid': False})
    qemu.almalinux-9-gencloud-bios-x86_64: changed: [default] => (item={'path': '/var/log/tallylog', 'mode': '0600', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 0, 'inode': 652849, 'dev': 2050, 'nlink': 1, 'atime': 1720432060.3115492, 'mtime': 1720432060.3115492, 'ctime': 1720432060.3115492, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': False, 'xgrp': False, 'woth': False, 'roth': False, 'xoth': False, 'isuid': False, 'isgid': False})
    qemu.almalinux-9-gencloud-bios-x86_64: changed: [default] => (item={'path': '/var/log/dnf.log', 'mode': '0644', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 47522, 'inode': 652951, 'dev': 2050, 'nlink': 1, 'atime': 1720432245.956901, 'mtime': 1720432349.97024, 'ctime': 1720432349.97024, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': True, 'xgrp': False, 'woth': False, 'roth': True, 'xoth': False, 'isuid': False, 'isgid': False})
    qemu.almalinux-9-gencloud-bios-x86_64: changed: [default] => (item={'path': '/var/log/dnf.librepo.log', 'mode': '0644', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 26581, 'inode': 652956, 'dev': 2050, 'nlink': 1, 'atime': 1720432245.956901, 'mtime': 1720432349.9112408, 'ctime': 1720432349.9112408, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': True, 'xgrp': False, 'woth': False, 'roth': True, 'xoth': False, 'isuid': False, 'isgid': False})
    qemu.almalinux-9-gencloud-bios-x86_64: changed: [default] => (item={'path': '/var/log/lastlog', 'mode': '0664', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 22, 'size': 0, 'inode': 652857, 'dev': 2050, 'nlink': 1, 'atime': 1720432220.4711955, 'mtime': 1720432354.5801835, 'ctime': 1720432354.5801835, 'gr_name': 'utmp', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': True, 'rgrp': True, 'xgrp': False, 'woth': False, 'roth': True, 'xoth': False, 'isuid': False, 'isgid': False})
    qemu.almalinux-9-gencloud-bios-x86_64: changed: [default] => (item={'path': '/var/log/dnf.rpm.log', 'mode': '0644', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 12363, 'inode': 652957, 'dev': 2050, 'nlink': 1, 'atime': 1720432245.9579012, 'mtime': 1720432349.9112408, 'ctime': 1720432349.9112408, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': True, 'xgrp': False, 'woth': False, 'roth': True, 'xoth': False, 'isuid': False, 'isgid': False})
    qemu.almalinux-9-gencloud-bios-x86_64: changed: [default] => (item={'path': '/var/log/hawkey.log', 'mode': '0644', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 1020, 'inode': 652958, 'dev': 2050, 'nlink': 1, 'atime': 1720432246.0059013, 'mtime': 1720432349.3982472, 'ctime': 1720432349.3982472, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': True, 'xgrp': False, 'woth': False, 'roth': True, 'xoth': False, 'isuid': False, 'isgid': False})
```

Verbosity of that is too high and unnecessary in my humble opinion. Aren't we against adding `loop_control` directive to the tasks? It helps reducing an output of the tasks to something like that:
```
    qemu.almalinux-9-gencloud-bios-x86_64: TASK [cleanup_vm : Remove log files] *******************************************
    qemu.almalinux-9-gencloud-bios-x86_64: changed: [default] => (item=/var/log/dnf.log)
    qemu.almalinux-9-gencloud-bios-x86_64: changed: [default] => (item=/var/log/maillog)
    qemu.almalinux-9-gencloud-bios-x86_64: changed: [default] => (item=/var/log/dnf.librepo.log)
    qemu.almalinux-9-gencloud-bios-x86_64: changed: [default] => (item=/var/log/dnf.rpm.log)
    qemu.almalinux-9-gencloud-bios-x86_64: changed: [default] => (item=/var/log/tallylog)
    qemu.almalinux-9-gencloud-bios-x86_64: changed: [default] => (item=/var/log/lastlog)
    qemu.almalinux-9-gencloud-bios-x86_64: changed: [default] => (item=/var/log/hawkey.log)
```