### PR TITLE
fix(vagrant): Remove update_and_reboot role

### DIFF
--- a/ansible/vagrant-box.yml
+++ b/ansible/vagrant-box.yml
@@ -7,7 +7,6 @@
     - almalinux.ci
 
   roles:
-    - upgrade_and_reboot
     - role: unified_boot
       when: is_unified_boot is defined
     - role: ezamriy.vbox_guest


### PR DESCRIPTION
This role returns random exit codes and confuses Ansible to give an error despite VM successfully reboots.

Since VM just created with boot ISO and every package downloaded from the repo.almalinux.org. This role does not have any effect but reboot and sometimes the trouble with Ansible.