### PR TITLE
feat: increase size of boot partition

### DIFF
--- a/http/almalinux-8.gencloud-aarch64.ks
+++ b/http/almalinux-8.gencloud-aarch64.ks
@@ -1,4 +1,4 @@
-# AlmaLinux 8 kickstart file for Generic Cloud (OpenStack) aarch64 image
+# AlmaLinux OS 8 kickstart file for OpenStack compatible Generic Cloud (Cloud-init) images on AArch64
 
 url --url https://repo.almalinux.org/almalinux/8/BaseOS/aarch64/kickstart/
 repo --name=BaseOS --baseurl=https://repo.almalinux.org/almalinux/8/BaseOS/aarch64/os/
@@ -8,13 +8,11 @@ text
 skipx
 eula --agreed
 firstboot --disabled
-
 lang en_US.UTF-8
 keyboard us
 timezone UTC --isUtc
-
 network --bootproto=dhcp
-firewall --enabled --service=ssh
+firewall --disabled
 services --disabled="kdump" --enabled="chronyd,rsyslog,sshd"
 selinux --enforcing
 
@@ -22,13 +20,12 @@ bootloader --timeout=0 --location=mbr --append="console=tty0 console=ttyS0,11520
 
 zerombr
 clearpart --all --initlabel
-reqpart
-part / --fstype="xfs" --size=8000
+part /boot/efi --fstype=efi --size=200
+part /boot --fstype=xfs --size=1024
+part / --fstype=xfs --grow
 
 rootpw --plaintext almalinux
-
 reboot --eject
-
 
 %packages
 @core
@@ -41,11 +38,6 @@ reboot --eject
 -iwl*-firmware
 %end
 
-
 # disable kdump service
 %addon com_redhat_kdump --disable
-%end
-
-
-%post
 %end

--- a/http/almalinux-8.gencloud-ppc64le.ks
+++ b/http/almalinux-8.gencloud-ppc64le.ks
@@ -1,4 +1,4 @@
-# AlmaLinux 8 kickstart file for Generic Cloud (OpenStack) ppc64le image
+# AlmaLinux OS 8 kickstart file for OpenStack compatible Generic Cloud (Cloud-init) images on ppc64le
 
 url --url https://repo.almalinux.org/almalinux/8/BaseOS/ppc64le/kickstart/
 repo --name=BaseOS --baseurl=https://repo.almalinux.org/almalinux/8/BaseOS/ppc64le/os/
@@ -8,13 +8,11 @@ text
 skipx
 eula --agreed
 firstboot --disabled
-
 lang en_US.UTF-8
 keyboard us
 timezone UTC --isUtc
-
 network --bootproto=dhcp
-firewall --enabled --service=ssh
+firewall --disabled
 services --disabled="kdump" --enabled="chronyd,rsyslog,sshd"
 selinux --enforcing
 
@@ -23,12 +21,11 @@ bootloader --timeout=0 --location=mbr --append="console=tty0 console=ttyS0,11520
 zerombr
 clearpart --all --initlabel
 reqpart
-part / --fstype="xfs" --size=8000
+part /boot --fstype=xfs --size=1024
+part / --fstype=xfs --grow
 
 rootpw --plaintext almalinux
-
 reboot --eject
-
 
 %packages
 @core
@@ -41,11 +38,6 @@ reboot --eject
 -iwl*-firmware
 %end
 
-
 # disable kdump service
 %addon com_redhat_kdump --disable
-%end
-
-
-%post
 %end

--- a/http/almalinux-9.gencloud-aarch64.ks
+++ b/http/almalinux-9.gencloud-aarch64.ks
@@ -1,4 +1,4 @@
-# AlmaLinux 9 kickstart file for Generic Cloud (OpenStack) aarch64 image
+# AlmaLinux OS 9 kickstart file for OpenStack compatible Generic Cloud (Cloud-init) images on AArch64
 
 url --url https://repo.almalinux.org/almalinux/9/BaseOS/aarch64/kickstart/
 repo --name=BaseOS --baseurl=https://repo.almalinux.org/almalinux/9/BaseOS/aarch64/os/
@@ -8,13 +8,11 @@ text
 skipx
 eula --agreed
 firstboot --disabled
-
 lang C.UTF-8
 keyboard us
 timezone UTC --utc
-
 network --bootproto=dhcp
-firewall --enabled --service=ssh
+firewall --disabled
 services --disabled="kdump" --enabled="chronyd,rsyslog,sshd"
 selinux --enforcing
 
@@ -22,14 +20,12 @@ bootloader --timeout=0 --location=mbr --append="console=tty0 console=ttyS0,11520
 
 zerombr
 clearpart --all --initlabel
-part /boot/efi --size=200 --fstype=efi
-part /boot --size=512 --fstype=xfs
-part / --size=8000 --fstype=xfs
+part /boot/efi --fstype=efi --size=200
+part /boot --fstype=xfs --size=1024
+part / --fstype=xfs --grow
 
 rootpw --plaintext almalinux
-
 reboot --eject
-
 
 %packages --inst-langs=en
 @core
@@ -46,7 +42,6 @@ usermode
 -plymouth
 -rhn*
 %end
-
 
 # disable kdump service
 %addon com_redhat_kdump --disable

--- a/http/almalinux-9.gencloud-ppc64le.ks
+++ b/http/almalinux-9.gencloud-ppc64le.ks
@@ -1,4 +1,4 @@
-# AlmaLinux 9 kickstart file for Generic Cloud (OpenStack) ppc64le image
+# AlmaLinux OS 9 kickstart file for OpenStack compatible Generic Cloud (Cloud-init) images on ppc64le
 
 url --url https://repo.almalinux.org/almalinux/9/BaseOS/ppc64le/kickstart/
 repo --name=BaseOS --baseurl=https://repo.almalinux.org/almalinux/9/BaseOS/ppc64le/os/
@@ -8,13 +8,11 @@ text
 skipx
 eula --agreed
 firstboot --disabled
-
 lang C.UTF-8
 keyboard us
 timezone UTC --utc
-
 network --bootproto=dhcp
-firewall --enabled --service=ssh
+firewall --disabled
 services --disabled="kdump" --enabled="chronyd,rsyslog,sshd"
 selinux --enforcing
 
@@ -23,13 +21,11 @@ bootloader --timeout=0 --location=mbr --append="console=tty0 console=ttyS0,11520
 zerombr
 clearpart --all --initlabel
 reqpart
-part /boot --size=512 --fstype=xfs
-part / --size=8000 --fstype=xfs
+part /boot --fstype=xfs --size=1024
+part / --fstype=xfs --grow
 
 rootpw --plaintext almalinux
-
 reboot --eject
-
 
 %packages --inst-langs=en
 @core
@@ -46,7 +42,6 @@ usermode
 -plymouth
 -rhn*
 %end
-
 
 # disable kdump service
 %addon com_redhat_kdump --disable

--- a/http/almalinux-9.gencloud-x86_64-bios.ks
+++ b/http/almalinux-9.gencloud-x86_64-bios.ks
@@ -1,4 +1,4 @@
-# AlmaLinux 9 kickstart file for Generic Cloud (OpenStack) x86_64-v2 image
+# AlmaLinux OS 9 kickstart file for OpenStack compatible Generic Cloud (Cloud-init) images with BIOS-only boot on x86_64
 
 url --url https://repo.almalinux.org/almalinux/9/BaseOS/x86_64/kickstart/
 repo --name=BaseOS --baseurl=https://repo.almalinux.org/almalinux/9/BaseOS/x86_64/os/
@@ -8,13 +8,11 @@ text
 skipx
 eula --agreed
 firstboot --disabled
-
 lang C.UTF-8
 keyboard us
 timezone UTC --utc
-
 network --bootproto=dhcp
-firewall --enabled --service=ssh
+firewall --disabled
 services --disabled="kdump" --enabled="chronyd,rsyslog,sshd"
 selinux --enforcing
 
@@ -26,9 +24,7 @@ reqpart
 part / --fstype="xfs" --size=8000
 
 rootpw --plaintext almalinux
-
 reboot --eject
-
 
 %packages --inst-langs=en
 @core
@@ -46,12 +42,13 @@ usermode
 -rhn*
 %end
 
-
 # disable kdump service
 %addon com_redhat_kdump --disable
 %end
 
 %post --erroronfail
+
 # permit root login via SSH with password authetication
 echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/01-permitrootlogin.conf
+
 %end

--- a/http/almalinux-9.gencloud-x86_64.ks
+++ b/http/almalinux-9.gencloud-x86_64.ks
@@ -1,4 +1,4 @@
-# AlmaLinux 9 kickstart file for Generic Cloud (OpenStack) x86-64-v2 image
+# AlmaLinux OS 9 kickstart file for OpenStack compatible Generic Cloud (Cloud-init) images with unified (BIOS+UEFI) boot on x86_64
 
 url --url https://repo.almalinux.org/almalinux/9/BaseOS/x86_64/kickstart/
 repo --name=BaseOS --baseurl=https://repo.almalinux.org/almalinux/9/BaseOS/x86_64/os/
@@ -8,13 +8,11 @@ text
 skipx
 eula --agreed
 firstboot --disabled
-
 lang C.UTF-8
 keyboard us
 timezone UTC --utc
-
 network --bootproto=dhcp
-firewall --enabled --service=ssh
+firewall --disabled
 services --disabled="kdump" --enabled="chronyd,rsyslog,sshd"
 selinux --enforcing
 
@@ -25,8 +23,8 @@ bootloader --timeout=0 --location=mbr --append="console=tty0 console=ttyS0,11520
 parted -s -a optimal /dev/sda -- mklabel gpt
 parted -s -a optimal /dev/sda -- mkpart biosboot 1MiB 2MiB set 1 bios_grub on
 parted -s -a optimal /dev/sda -- mkpart '"EFI System Partition"' fat32 2MiB 202MiB set 2 esp on
-parted -s -a optimal /dev/sda -- mkpart boot xfs 202MiB 714MiB
-parted -s -a optimal /dev/sda -- mkpart root xfs 714MiB 100%
+parted -s -a optimal /dev/sda -- mkpart boot xfs 202MiB 1226MiB
+parted -s -a optimal /dev/sda -- mkpart root xfs 1226MiB 100%
 
 %end
 
@@ -38,7 +36,6 @@ part / --fstype=xfs --onpart=sda4
 rootpw --plaintext almalinux
 
 reboot --eject
-
 
 %packages --inst-langs=en
 @core
@@ -57,14 +54,21 @@ usermode
 -rhn*
 %end
 
-
 # disable kdump service
 %addon com_redhat_kdump --disable
 %end
 
 %post --erroronfail
 
-grub2-install --target=i386-pc /dev/sda
+EX_NOINPUT=66
+
+root_disk=$(grub2-probe --target=disk /boot/grub2)
+
+if [[ "$root_disk" =~ ^"/dev/" ]]; then
+    grub2-install --target=i386-pc "$root_disk"
+else
+    exit "$EX_NOINPUT"
+fi
 
 # permit root login via SSH with password authetication
 echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/01-permitrootlogin.conf

--- a/http/almalinux-9.vagrant-aarch64.ks
+++ b/http/almalinux-9.vagrant-aarch64.ks
@@ -1,4 +1,4 @@
-# AlmaLinux 9 aarch64 kickstart file for Vagrant boxes
+# AlmaLinux OS 9 kickstart file for Vagrant boxes on AArch64
 
 url --url https://repo.almalinux.org/almalinux/9/BaseOS/aarch64/kickstart/
 repo --name=BaseOS --baseurl=https://repo.almalinux.org/almalinux/9/BaseOS/aarch64/os/
@@ -8,11 +8,9 @@ text
 skipx
 eula --agreed
 firstboot --disabled
-
 lang C.UTF-8
 keyboard us
 timezone UTC --utc
-
 network --bootproto=dhcp
 firewall --disabled
 services --enabled=sshd
@@ -22,13 +20,13 @@ bootloader --timeout=0 --location=mbr --append="console=tty0 console=ttyS0,11520
 
 zerombr
 clearpart --all --initlabel
-autopart --type=plain --nohome --noboot --noswap
+part /boot/efi --fstype=efi --size=200
+part /boot --fstype=xfs --size=1024
+part / --fstype=xfs --grow
 
 rootpw vagrant
 user --name=vagrant --plaintext --password vagrant
-
 reboot --eject
-
 
 %packages --inst-langs=en
 @core
@@ -48,20 +46,18 @@ usermode
 -rhn*
 %end
 
-
 # disable kdump service
 %addon com_redhat_kdump --disable
 %end
 
+%post --erroronfail
 
-%post
 # allow vagrant user to run everything without a password
 echo "vagrant     ALL=(ALL)     NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
 
 # see Vagrant documentation (https://docs.vagrantup.com/v2/boxes/base.html)
 # for details about the requiretty.
 sed -i "s/^.*requiretty/# Defaults requiretty/" /etc/sudoers
-yum clean all
 
 # permit root login via SSH with password authetication
 echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/01-permitrootlogin.conf

--- a/http/almalinux-9.vagrant-x86_64.ks
+++ b/http/almalinux-9.vagrant-x86_64.ks
@@ -1,4 +1,4 @@
-# AlmaLinux 9 kickstart file for Vagrant boxes
+# AlmaLinux OS 9 kickstart file for Vagrant boxes with unified (BIOS+UEFI) boot on x86_64
 
 url --url https://repo.almalinux.org/almalinux/9/BaseOS/x86_64/kickstart/
 repo --name=BaseOS --baseurl=https://repo.almalinux.org/almalinux/9/BaseOS/x86_64/os/
@@ -8,11 +8,9 @@ text
 skipx
 eula --agreed
 firstboot --disabled
-
 lang C.UTF-8
 keyboard us
 timezone UTC --utc
-
 network --bootproto=dhcp
 firewall --disabled
 services --enabled=sshd
@@ -25,8 +23,8 @@ bootloader --timeout=0 --location=mbr --append="console=tty0 console=ttyS0,11520
 parted -s -a optimal /dev/sda -- mklabel gpt
 parted -s -a optimal /dev/sda -- mkpart biosboot 1MiB 2MiB set 1 bios_grub on
 parted -s -a optimal /dev/sda -- mkpart '"EFI System Partition"' fat32 2MiB 202MiB set 2 esp on
-parted -s -a optimal /dev/sda -- mkpart boot xfs 202MiB 714MiB
-parted -s -a optimal /dev/sda -- mkpart root xfs 714MiB 100%
+parted -s -a optimal /dev/sda -- mkpart boot xfs 202MiB 1226MiB
+parted -s -a optimal /dev/sda -- mkpart root xfs 1226MiB 100%
 
 %end
 
@@ -35,12 +33,9 @@ part /boot/efi --fstype=efi --onpart=sda2
 part /boot --fstype=xfs --onpart=sda3
 part / --fstype=xfs --onpart=sda4
 
-
 rootpw vagrant
 user --name=vagrant --plaintext --password vagrant
-
 reboot --eject
-
 
 %packages --inst-langs=en
 @core
@@ -61,14 +56,21 @@ usermode
 -rhn*
 %end
 
-
 # disable kdump service
 %addon com_redhat_kdump --disable
 %end
 
 %post --erroronfail
 
-grub2-install --target=i386-pc /dev/sda
+EX_NOINPUT=66
+
+root_disk=$(grub2-probe --target=disk /boot/grub2)
+
+if [[ "$root_disk" =~ ^"/dev/" ]]; then
+    grub2-install --target=i386-pc "$root_disk"
+else
+    exit "$EX_NOINPUT"
+fi
 
 # allow vagrant user to run everything without a password
 echo "vagrant     ALL=(ALL)     NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
@@ -76,7 +78,6 @@ echo "vagrant     ALL=(ALL)     NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
 # see Vagrant documentation (https://docs.vagrantup.com/v2/boxes/base.html)
 # for details about the requiretty.
 sed -i "s/^.*requiretty/# Defaults requiretty/" /etc/sudoers
-yum clean all
 
 # permit root login via SSH with password authetication
 echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/01-permitrootlogin.conf


### PR DESCRIPTION
Increase the size of boot (/boot) partition from 512 MiB to 1024 MiB.

By default the DNF package manager is configured to hold three different versions of kernel packages[^1].
While the 512 MiB boot size is enough on the majority use cases, There are other use cases where the initramfs (initial ram file system) may be bigger than usual. Since the kernel (vmlinuz) and initramfs resides on the boot partition.
Even having three installed kernel may be impossible.

It is worth mentioning that rescue initramfs is larger than regular ones.

This commit aims to address this issue with incrementing the size of boot partition from 512 MiB to 1024 MiB. Such amount of size should work well nearly all situations and use cases where larger size of initramfs and more number of kernels are present on the boot filesystem.

[^1]: See installonly_limit main option ([main]) on /etc/dnf.conf