### PR TITLE
fix(hyperv): make lf consistent on kickstart files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Line endings are converted from LF to CRLF on Windows.
+# Anaconda installer doesn't understand kickstart files with CRLF line endings.
+*.ks text eol=lf


### PR DESCRIPTION
The Git for windows converts the line endings of files from LF to the native format which is CRLF on Windows.
Since the Anaconda Installer cannot understand such line endings on the kickstart files, make the line endings consistent as LF on all kickstart files.