### PR TITLE
fix(packer): fixes and formatting

### DIFF
--- a/almalinux-8-azure.pkr.hcl
+++ b/almalinux-8-azure.pkr.hcl
@@ -32,7 +32,7 @@ source "qemu" "almalinux-8-azure-x86_64" {
 }
 
 build {
-  sources = ["qemu.almalinux-8-azure-x86_64"]
+  sources = ["source.qemu.almalinux-8-azure-x86_64"]
 
   provisioner "ansible" {
     galaxy_file          = "./ansible/requirements.yml"
@@ -43,10 +43,11 @@ build {
     ansible_env_vars = [
       "ANSIBLE_PIPELINING=True",
       "ANSIBLE_REMOTE_TEMP=/tmp",
-      "ANSIBLE_SCP_EXTRA_ARGS=-O"
+      "ANSIBLE_SCP_EXTRA_ARGS=-O",
     ]
     extra_arguments = [
-      "--extra-vars", "is_unified_boot=true"
+      "--extra-vars",
+      "is_unified_boot=true",
     ]
   }
 }

--- a/almalinux-8-digitalocean.pkr.hcl
+++ b/almalinux-8-digitalocean.pkr.hcl
@@ -33,7 +33,8 @@ source "qemu" "almalinux-8-digitalocean-x86_64" {
 }
 
 build {
-  sources = ["qemu.almalinux-8-digitalocean-x86_64"]
+  sources = ["source.qemu.almalinux-8-digitalocean-x86_64"]
+
   provisioner "ansible" {
     galaxy_file          = "./ansible/requirements.yml"
     galaxy_force_install = true
@@ -43,16 +44,16 @@ build {
     ansible_env_vars = [
       "ANSIBLE_PIPELINING=True",
       "ANSIBLE_REMOTE_TEMP=/tmp",
-      "ANSIBLE_SCP_EXTRA_ARGS=-O"
+      "ANSIBLE_SCP_EXTRA_ARGS=-O",
     ]
     extra_arguments = [
-      "--extra-vars", "is_unified_boot=true"
+      "--extra-vars",
+      "is_unified_boot=true",
     ]
   }
+
   provisioner "shell" {
-    scripts = [
-      "vm-scripts/digitalocean/99-img-check.sh"
-    ]
+    scripts = ["vm-scripts/digitalocean/99-img-check.sh"]
   }
 
   post-processor "digitalocean-import" {

--- a/almalinux-8-gencloud.pkr.hcl
+++ b/almalinux-8-gencloud.pkr.hcl
@@ -62,7 +62,7 @@ source "qemu" "almalinux-8-gencloud-aarch64" {
   cpus               = var.cpus
   qemuargs = [
     ["-boot", "strict=on"],
-    ["-monitor", "none"]
+    ["-monitor", "none"],
   ]
 }
 
@@ -94,9 +94,9 @@ source "qemu" "almalinux-8-gencloud-ppc64le" {
 
 build {
   sources = [
-    "qemu.almalinux-8-gencloud-x86_64",
-    "qemu.almalinux-8-gencloud-aarch64",
-    "qemu.almalinux-8-gencloud-ppc64le"
+    "source.qemu.almalinux-8-gencloud-x86_64",
+    "source.qemu.almalinux-8-gencloud-aarch64",
+    "source.qemu.almalinux-8-gencloud-ppc64le",
   ]
 
   provisioner "ansible" {
@@ -108,10 +108,11 @@ build {
     ansible_env_vars = [
       "ANSIBLE_PIPELINING=True",
       "ANSIBLE_REMOTE_TEMP=/tmp",
-      "ANSIBLE_SCP_EXTRA_ARGS=-O"
+      "ANSIBLE_SCP_EXTRA_ARGS=-O",
     ]
     extra_arguments = [
-      "--extra-vars", "is_unified_boot=true"
+      "--extra-vars",
+      "is_unified_boot=true",
     ]
     only = ["qemu.almalinux-8-gencloud-x86_64"]
   }
@@ -125,11 +126,11 @@ build {
     ansible_env_vars = [
       "ANSIBLE_PIPELINING=True",
       "ANSIBLE_REMOTE_TEMP=/tmp",
-      "ANSIBLE_SCP_EXTRA_ARGS=-O"
+      "ANSIBLE_SCP_EXTRA_ARGS=-O",
     ]
     only = [
       "qemu.almalinux-8-gencloud-aarch64",
-      "qemu.almalinux-8-gencloud-ppc64le"
+      "qemu.almalinux-8-gencloud-ppc64le",
     ]
   }
 }

--- a/almalinux-8-oci.pkr.hcl
+++ b/almalinux-8-oci.pkr.hcl
@@ -62,14 +62,14 @@ source "qemu" "almalinux-8-oci-aarch64" {
   cpus               = var.cpus
   qemuargs = [
     ["-boot", "strict=on"],
-    ["-monitor", "none"]
+    ["-monitor", "none"],
   ]
 }
 
 build {
   sources = [
-    "qemu.almalinux-8-oci-x86_64",
-    "qemu.almalinux-8-oci-aarch64"
+    "source.qemu.almalinux-8-oci-x86_64",
+    "source.qemu.almalinux-8-oci-aarch64",
   ]
 
   provisioner "ansible" {
@@ -81,10 +81,11 @@ build {
     ansible_env_vars = [
       "ANSIBLE_PIPELINING=True",
       "ANSIBLE_REMOTE_TEMP=/tmp",
-      "ANSIBLE_SCP_EXTRA_ARGS=-O"
+      "ANSIBLE_SCP_EXTRA_ARGS=-O",
     ]
     extra_arguments = [
-      "--extra-vars", "is_unified_boot=true"
+      "--extra-vars",
+      "is_unified_boot=true",
     ]
     only = ["qemu.almalinux-8-oci-x86_64"]
   }
@@ -98,7 +99,7 @@ build {
     ansible_env_vars = [
       "ANSIBLE_PIPELINING=True",
       "ANSIBLE_REMOTE_TEMP=/tmp",
-      "ANSIBLE_SCP_EXTRA_ARGS=-O"
+      "ANSIBLE_SCP_EXTRA_ARGS=-O",
     ]
     only = ["qemu.almalinux-8-oci-aarch64"]
   }

--- a/almalinux-8-opennebula.pkr.hcl
+++ b/almalinux-8-opennebula.pkr.hcl
@@ -62,15 +62,16 @@ source "qemu" "almalinux-8-opennebula-aarch64" {
   cpus               = var.cpus
   qemuargs = [
     ["-boot", "strict=on"],
-    ["-monitor", "none"]
+    ["-monitor", "none"],
   ]
 }
 
 build {
   sources = [
-    "qemu.almalinux-8-opennebula-x86_64",
-    "qemu.almalinux-8-opennebula-aarch64"
+    "source.qemu.almalinux-8-opennebula-x86_64",
+    "source.qemu.almalinux-8-opennebula-aarch64",
   ]
+
   provisioner "ansible" {
     galaxy_file          = "./ansible/requirements.yml"
     galaxy_force_install = true
@@ -80,13 +81,15 @@ build {
     ansible_env_vars = [
       "ANSIBLE_PIPELINING=True",
       "ANSIBLE_REMOTE_TEMP=/tmp",
-      "ANSIBLE_SCP_EXTRA_ARGS=-O"
+      "ANSIBLE_SCP_EXTRA_ARGS=-O",
     ]
     extra_arguments = [
-      "--extra-vars", "is_unified_boot=true"
+      "--extra-vars",
+      "is_unified_boot=true",
     ]
     only = ["qemu.almalinux-8-opennebula-x86_64"]
   }
+
   provisioner "ansible" {
     galaxy_file          = "./ansible/requirements.yml"
     galaxy_force_install = true
@@ -96,7 +99,7 @@ build {
     ansible_env_vars = [
       "ANSIBLE_PIPELINING=True",
       "ANSIBLE_REMOTE_TEMP=/tmp",
-      "ANSIBLE_SCP_EXTRA_ARGS=-O"
+      "ANSIBLE_SCP_EXTRA_ARGS=-O",
     ]
     only = ["qemu.almalinux-8-opennebula-aarch64"]
   }

--- a/almalinux-8-vagrant.pkr.hcl
+++ b/almalinux-8-vagrant.pkr.hcl
@@ -50,12 +50,10 @@ source "virtualbox-iso" "almalinux-8" {
   headless             = var.headless
   hard_drive_interface = "sata"
   iso_interface        = "sata"
-  vboxmanage = [
-    ["modifyvm", "{{.Name}}", "--nat-localhostreachable1", "on"],
-  ]
+  vboxmanage           = [["modifyvm", "{{.Name}}", "--nat-localhostreachable1", "on"]]
   vboxmanage_post = [
     ["modifyvm", "{{.Name}}", "--memory", var.post_memory],
-    ["modifyvm", "{{.Name}}", "--cpus", var.post_cpus]
+    ["modifyvm", "{{.Name}}", "--cpus", var.post_cpus],
   ]
 }
 
@@ -81,29 +79,28 @@ source "hyperv-iso" "almalinux-8" {
 }
 
 source "vmware-iso" "almalinux-8" {
-  iso_url          = local.iso_url_8_x86_64
-  iso_checksum     = local.iso_checksum_8_x86_64
-  http_directory   = var.http_directory
-  shutdown_command = var.vagrant_shutdown_command
-  ssh_username     = var.vagrant_ssh_username
-  ssh_password     = var.vagrant_ssh_password
-  ssh_timeout      = var.ssh_timeout
-  boot_command     = var.vagrant_boot_command_8_x86_64_bios
-  boot_wait        = var.boot_wait
-  disk_size        = var.vagrant_disk_size
-  guest_os_type    = "centos-64"
-  cpus             = var.cpus
-  memory           = var.memory
-  headless         = var.headless
+  iso_url                        = local.iso_url_8_x86_64
+  iso_checksum                   = local.iso_checksum_8_x86_64
+  http_directory                 = var.http_directory
+  shutdown_command               = var.vagrant_shutdown_command
+  ssh_username                   = var.vagrant_ssh_username
+  ssh_password                   = var.vagrant_ssh_password
+  ssh_timeout                    = var.ssh_timeout
+  boot_command                   = var.vagrant_boot_command_8_x86_64_bios
+  boot_wait                      = var.boot_wait
+  disk_size                      = var.vagrant_disk_size
+  guest_os_type                  = "centos-64"
+  cpus                           = var.cpus
+  memory                         = var.memory
+  headless                       = var.headless
+  vmx_remove_ethernet_interfaces = true
   vmx_data = {
-    "cpuid.coresPerSocket" : "1"
+    "cpuid.coresPerSocket" = "1"
   }
   vmx_data_post = {
-    "memsize" : var.post_memory
-    "numvcpus" : var.post_cpus
+    "memsize"  = var.post_memory
+    "numvcpus" = var.post_cpus
   }
-
-  vmx_remove_ethernet_interfaces = true
 }
 
 source "parallels-iso" "almalinux-8" {
@@ -125,11 +122,11 @@ source "parallels-iso" "almalinux-8" {
 
 build {
   sources = [
-    "qemu.almalinux-8",
-    "virtualbox-iso.almalinux-8",
-    "hyperv-iso.almalinux-8",
-    "vmware-iso.almalinux-8",
-    "parallels-iso.almalinux-8"
+    "source.qemu.almalinux-8",
+    "source.virtualbox-iso.almalinux-8",
+    "source.hyperv-iso.almalinux-8",
+    "source.vmware-iso.almalinux-8",
+    "source.parallels-iso.almalinux-8",
   ]
 
   provisioner "ansible" {
@@ -141,11 +138,11 @@ build {
     ansible_env_vars = [
       "ANSIBLE_PIPELINING=True",
       "ANSIBLE_REMOTE_TEMP=/tmp",
-      "ANSIBLE_SCP_EXTRA_ARGS=-O"
+      "ANSIBLE_SCP_EXTRA_ARGS=-O",
     ]
     extra_arguments = [
       "--extra-vars",
-      "packer_provider=${source.type} is_unified_boot=true"
+      "packer_provider=${source.type} is_unified_boot=true",
     ]
     only = [
       "qemu.almalinux-8",
@@ -165,25 +162,19 @@ build {
       "ANSIBLE_PIPELINING=True",
       "ANSIBLE_REMOTE_TEMP=/tmp",
       "ANSIBLE_SCP_EXTRA_ARGS=-O",
-      "ANSIBLE_HOST_KEY_CHECKING=False"
+      "ANSIBLE_HOST_KEY_CHECKING=False",
     ]
     extra_arguments = [
       "--extra-vars",
-      "packer_provider=${source.type} ansible_ssh_pass=vagrant is_unified_boot=true"
+      "packer_provider=${source.type} ansible_ssh_pass=vagrant is_unified_boot=true",
     ]
-    only = [
-      "hyperv-iso.almalinux-8"
-    ]
+    only = ["hyperv-iso.almalinux-8"]
   }
 
   provisioner "shell" {
     expect_disconnect = true
-    inline = [
-      "sudo rm -fr /etc/ssh/*host*key*"
-    ]
-    only = [
-      "hyperv-iso.almalinux-8"
-    ]
+    inline            = ["sudo rm -fr /etc/ssh/*host*key*"]
+    only              = ["hyperv-iso.almalinux-8"]
   }
 
   provisioner "ansible" {
@@ -195,15 +186,15 @@ build {
     ansible_env_vars = [
       "ANSIBLE_PIPELINING=True",
       "ANSIBLE_REMOTE_TEMP=/tmp",
-      "ANSIBLE_SCP_EXTRA_ARGS=-O"
+      "ANSIBLE_SCP_EXTRA_ARGS=-O",
     ]
     extra_arguments = [
       "--extra-vars",
-      "packer_provider=${source.type}"
+      "packer_provider=${source.type}",
     ]
     only = [
       "vmware-iso.almalinux-8",
-      "parallels-iso.almalinux-8"
+      "parallels-iso.almalinux-8",
     ]
   }
 
@@ -213,9 +204,7 @@ build {
       compression_level    = "9"
       vagrantfile_template = "tpl/vagrant/vagrantfile-libvirt.rb"
       output               = "AlmaLinux-8-Vagrant-${var.os_ver_8}-${formatdate("YYYYMMDD", timestamp())}.x86_64.{{.Provider}}.box"
-      only = [
-        "qemu.almalinux-8"
-      ]
+      only                 = ["qemu.almalinux-8"]
     }
 
     post-processor "vagrant" {
@@ -225,7 +214,7 @@ build {
         "virtualbox-iso.almalinux-8",
         "hyperv-iso.almalinux-8",
         "vmware-iso.almalinux-8",
-        "parallels-iso.almalinux-8"
+        "parallels-iso.almalinux-8",
       ]
     }
   }

--- a/almalinux-9-azure.pkr.hcl
+++ b/almalinux-9-azure.pkr.hcl
@@ -32,7 +32,7 @@ source "qemu" "almalinux-9-azure-x86_64" {
 }
 
 build {
-  sources = ["qemu.almalinux-9-azure-x86_64"]
+  sources = ["source.qemu.almalinux-9-azure-x86_64"]
 
   provisioner "ansible" {
     galaxy_file          = "./ansible/requirements.yml"
@@ -43,7 +43,7 @@ build {
     ansible_env_vars = [
       "ANSIBLE_PIPELINING=True",
       "ANSIBLE_REMOTE_TEMP=/tmp",
-      "ANSIBLE_SCP_EXTRA_ARGS=-O"
+      "ANSIBLE_SCP_EXTRA_ARGS=-O",
     ]
   }
 }

--- a/almalinux-9-digitalocean.pkr.hcl
+++ b/almalinux-9-digitalocean.pkr.hcl
@@ -33,7 +33,7 @@ source "qemu" "almalinux-9-digitalocean-x86_64" {
 }
 
 build {
-  sources = ["qemu.almalinux-9-digitalocean-x86_64"]
+  sources = ["source.qemu.almalinux-9-digitalocean-x86_64"]
 
   provisioner "ansible" {
     galaxy_file          = "./ansible/requirements.yml"
@@ -44,14 +44,12 @@ build {
     ansible_env_vars = [
       "ANSIBLE_PIPELINING=True",
       "ANSIBLE_REMOTE_TEMP=/tmp",
-      "ANSIBLE_SCP_EXTRA_ARGS=-O"
+      "ANSIBLE_SCP_EXTRA_ARGS=-O",
     ]
   }
 
   provisioner "shell" {
-    scripts = [
-      "vm-scripts/digitalocean/99-img-check.sh"
-    ]
+    scripts = ["vm-scripts/digitalocean/99-img-check.sh"]
   }
 
   post-processor "digitalocean-import" {

--- a/almalinux-9-gencloud.pkr.hcl
+++ b/almalinux-9-gencloud.pkr.hcl
@@ -62,7 +62,7 @@ source "qemu" "almalinux-9-gencloud-aarch64" {
   cpus               = var.cpus
   qemuargs = [
     ["-boot", "strict=on"],
-    ["-monitor", "none"]
+    ["-monitor", "none"],
   ]
 }
 
@@ -94,9 +94,9 @@ source "qemu" "almalinux-9-gencloud-ppc64le" {
 
 build {
   sources = [
-    "qemu.almalinux-9-gencloud-x86_64",
-    "qemu.almalinux-9-gencloud-aarch64",
-    "qemu.almalinux-9-gencloud-ppc64le"
+    "source.qemu.almalinux-9-gencloud-x86_64",
+    "source.qemu.almalinux-9-gencloud-aarch64",
+    "source.qemu.almalinux-9-gencloud-ppc64le",
   ]
 
   provisioner "ansible" {
@@ -108,7 +108,7 @@ build {
     ansible_env_vars = [
       "ANSIBLE_PIPELINING=True",
       "ANSIBLE_REMOTE_TEMP=/tmp",
-      "ANSIBLE_SCP_EXTRA_ARGS=-O"
+      "ANSIBLE_SCP_EXTRA_ARGS=-O",
     ]
   }
 }

--- a/almalinux-9-oci.pkr.hcl
+++ b/almalinux-9-oci.pkr.hcl
@@ -62,14 +62,14 @@ source "qemu" "almalinux-9-oci-aarch64" {
   cpus               = var.cpus
   qemuargs = [
     ["-boot", "strict=on"],
-    ["-monitor", "none"]
+    ["-monitor", "none"],
   ]
 }
 
 build {
   sources = [
-    "qemu.almalinux-9-oci-x86_64",
-    "qemu.almalinux-9-oci-aarch64"
+    "source.qemu.almalinux-9-oci-x86_64",
+    "source.qemu.almalinux-9-oci-aarch64",
   ]
 
   provisioner "ansible" {
@@ -81,7 +81,7 @@ build {
     ansible_env_vars = [
       "ANSIBLE_PIPELINING=True",
       "ANSIBLE_REMOTE_TEMP=/tmp",
-      "ANSIBLE_SCP_EXTRA_ARGS=-O"
+      "ANSIBLE_SCP_EXTRA_ARGS=-O",
     ]
   }
 }

--- a/almalinux-9-opennebula.pkr.hcl
+++ b/almalinux-9-opennebula.pkr.hcl
@@ -62,14 +62,14 @@ source "qemu" "almalinux-9-opennebula-aarch64" {
   cpus               = var.cpus
   qemuargs = [
     ["-boot", "strict=on"],
-    ["-monitor", "none"]
+    ["-monitor", "none"],
   ]
 }
 
 build {
   sources = [
-    "qemu.almalinux-9-opennebula-x86_64",
-    "qemu.almalinux-9-opennebula-aarch64"
+    "source.qemu.almalinux-9-opennebula-x86_64",
+    "source.qemu.almalinux-9-opennebula-aarch64",
   ]
 
   provisioner "ansible" {
@@ -81,7 +81,7 @@ build {
     ansible_env_vars = [
       "ANSIBLE_PIPELINING=True",
       "ANSIBLE_REMOTE_TEMP=/tmp",
-      "ANSIBLE_SCP_EXTRA_ARGS=-O"
+      "ANSIBLE_SCP_EXTRA_ARGS=-O",
     ]
   }
 }

--- a/almalinux-9-vagrant.pkr.hcl
+++ b/almalinux-9-vagrant.pkr.hcl
@@ -50,12 +50,10 @@ source "virtualbox-iso" "almalinux-9" {
   headless             = var.headless
   hard_drive_interface = "sata"
   iso_interface        = "sata"
-  vboxmanage = [
-    ["modifyvm", "{{.Name}}", "--nat-localhostreachable1", "on"],
-  ]
+  vboxmanage           = [["modifyvm", "{{.Name}}", "--nat-localhostreachable1", "on"]]
   vboxmanage_post = [
     ["modifyvm", "{{.Name}}", "--memory", var.post_memory],
-    ["modifyvm", "{{.Name}}", "--cpus", var.post_cpus]
+    ["modifyvm", "{{.Name}}", "--cpus", var.post_cpus],
   ]
 }
 
@@ -81,29 +79,28 @@ source "hyperv-iso" "almalinux-9" {
 }
 
 source "vmware-iso" "almalinux-9" {
-  iso_url          = local.iso_url_9_x86_64
-  iso_checksum     = local.iso_checksum_9_x86_64
-  http_directory   = var.http_directory
-  shutdown_command = var.vagrant_shutdown_command
-  ssh_username     = var.vagrant_ssh_username
-  ssh_password     = var.vagrant_ssh_password
-  ssh_timeout      = var.ssh_timeout
-  boot_command     = var.vagrant_boot_command_9_x86_64_bios
-  boot_wait        = var.boot_wait
-  disk_size        = var.vagrant_disk_size
-  guest_os_type    = "centos-64"
-  cpus             = var.cpus
-  memory           = var.memory
-  headless         = var.headless
+  iso_url                        = local.iso_url_9_x86_64
+  iso_checksum                   = local.iso_checksum_9_x86_64
+  http_directory                 = var.http_directory
+  shutdown_command               = var.vagrant_shutdown_command
+  ssh_username                   = var.vagrant_ssh_username
+  ssh_password                   = var.vagrant_ssh_password
+  ssh_timeout                    = var.ssh_timeout
+  boot_command                   = var.vagrant_boot_command_9_x86_64_bios
+  boot_wait                      = var.boot_wait
+  disk_size                      = var.vagrant_disk_size
+  guest_os_type                  = "centos-64"
+  cpus                           = var.cpus
+  memory                         = var.memory
+  headless                       = var.headless
+  vmx_remove_ethernet_interfaces = true
   vmx_data = {
-    "cpuid.coresPerSocket" : "1"
+    "cpuid.coresPerSocket" = "1"
   }
   vmx_data_post = {
-    "memsize" : var.post_memory
-    "numvcpus" : var.post_cpus
+    "memsize"  = var.post_memory
+    "numvcpus" = var.post_cpus
   }
-
-  vmx_remove_ethernet_interfaces = true
 }
 
 source "parallels-iso" "almalinux-9" {
@@ -124,32 +121,32 @@ source "parallels-iso" "almalinux-9" {
 }
 
 source "vmware-iso" "almalinux-9-aarch64" {
-  iso_url          = local.iso_url_9_aarch64
-  iso_checksum     = local.iso_checksum_9_aarch64
-  http_directory   = var.http_directory
-  shutdown_command = var.vagrant_shutdown_command
-  ssh_username     = var.vagrant_ssh_username
-  ssh_password     = var.vagrant_ssh_password
-  ssh_timeout      = var.ssh_timeout
-  boot_command     = var.vagrant_boot_command_9_aarch64
-  boot_wait        = var.boot_wait
-  disk_size        = var.vagrant_disk_size
-  guest_os_type    = "arm-rhel9-64"
-  cpus             = var.cpus
-  memory           = var.memory
-  headless         = var.headless
-  vmx_data = {
-    ".encoding"            = "UTF-8",
-    "config.version"       = "8",
-    "virtualHW.version"    = "20",
-    "usb_xhci.present"     = "true",
-    "ethernet0.virtualdev" = "e1000e",
-    "firmware"             = "efi"
-  }
+  iso_url                        = local.iso_url_9_aarch64
+  iso_checksum                   = local.iso_checksum_9_aarch64
+  http_directory                 = var.http_directory
+  shutdown_command               = var.vagrant_shutdown_command
+  ssh_username                   = var.vagrant_ssh_username
+  ssh_password                   = var.vagrant_ssh_password
+  ssh_timeout                    = var.ssh_timeout
+  boot_command                   = var.vagrant_boot_command_9_aarch64
+  boot_wait                      = var.boot_wait
+  disk_size                      = var.vagrant_disk_size
+  guest_os_type                  = "arm-rhel9-64"
+  cpus                           = var.cpus
+  memory                         = var.memory
+  headless                       = var.headless
   vmx_remove_ethernet_interfaces = true
   vm_name                        = "almalinux-9"
   usb                            = true
   disk_adapter_type              = "nvme"
+  vmx_data = {
+    ".encoding"            = "UTF-8"
+    "config.version"       = "8"
+    "virtualHW.version"    = "20"
+    "usb_xhci.present"     = "true"
+    "ethernet0.virtualdev" = "e1000e"
+    "firmware"             = "efi"
+  }
 }
 
 source "parallels-iso" "almalinux-9-aarch64" {
@@ -185,25 +182,23 @@ source "virtualbox-iso" "almalinux-9-aarch64" {
   memory               = var.memory
   headless             = var.headless
   hard_drive_interface = "sata"
-  vboxmanage = [
-    ["modifyvm", "{{.Name}}", "--nat-localhostreachable1", "on"],
-  ]
+  vboxmanage           = [["modifyvm", "{{.Name}}", "--nat-localhostreachable1", "on"]]
   vboxmanage_post = [
     ["modifyvm", "{{.Name}}", "--memory", var.post_memory],
-    ["modifyvm", "{{.Name}}", "--cpus", var.post_cpus]
+    ["modifyvm", "{{.Name}}", "--cpus", var.post_cpus],
   ]
 }
 
 build {
   sources = [
-    "sources.qemu.almalinux-9",
-    "sources.virtualbox-iso.almalinux-9",
-    "sources.hyperv-iso.almalinux-9",
-    "sources.vmware-iso.almalinux-9",
-    "sources.parallels-iso.almalinux-9",
-    "sources.virtualbox-iso.almalinux-9-aarch64",
-    "sources.vmware-iso.almalinux-9-aarch64",
-    "sources.parallels-iso.almalinux-9-aarch64"
+    "source.qemu.almalinux-9",
+    "source.virtualbox-iso.almalinux-9",
+    "source.hyperv-iso.almalinux-9",
+    "source.vmware-iso.almalinux-9",
+    "source.parallels-iso.almalinux-9",
+    "source.virtualbox-iso.almalinux-9-aarch64",
+    "source.vmware-iso.almalinux-9-aarch64",
+    "source.parallels-iso.almalinux-9-aarch64",
   ]
 
   provisioner "ansible" {
@@ -215,20 +210,20 @@ build {
     ansible_env_vars = [
       "ANSIBLE_PIPELINING=True",
       "ANSIBLE_REMOTE_TEMP=/tmp",
-      "ANSIBLE_SCP_EXTRA_ARGS=-O"
+      "ANSIBLE_SCP_EXTRA_ARGS=-O",
     ]
     extra_arguments = [
       "--extra-vars",
-      "packer_provider=${source.type}"
+      "packer_provider=${source.type}",
     ]
     only = [
-      "sources.qemu.almalinux-9",
-      "sources.virtualbox-iso.almalinux-9",
-      "sources.vmware-iso.almalinux-9",
-      "sources.parallels-iso.almalinux-9",
-      "sources.virtualbox-iso.almalinux-9-aarch64",
-      "sources.vmware-iso.almalinux-9-aarch64",
-      "sources.parallels-iso.almalinux-9-aarch64"
+      "qemu.almalinux-9",
+      "virtualbox-iso.almalinux-9",
+      "vmware-iso.almalinux-9",
+      "parallels-iso.almalinux-9",
+      "virtualbox-iso.almalinux-9-aarch64",
+      "vmware-iso.almalinux-9-aarch64",
+      "parallels-iso.almalinux-9-aarch64",
     ]
   }
 
@@ -243,25 +238,20 @@ build {
     ansible_env_vars = [
       "ANSIBLE_PIPELINING=True",
       "ANSIBLE_REMOTE_TEMP=/tmp",
-      "ANSIBLE_SCP_EXTRA_ARGS=-O"
+      "ANSIBLE_SCP_EXTRA_ARGS=-O",
+      "ANSIBLE_HOST_KEY_CHECKING=False",
     ]
     extra_arguments = [
       "--extra-vars",
-      "packer_provider=${source.type} ansible_ssh_pass=vagrant"
+      "packer_provider=${source.type} ansible_ssh_pass=vagrant",
     ]
-    only = [
-      "hyperv-iso.almalinux-9"
-    ]
+    only = ["hyperv-iso.almalinux-9"]
   }
 
   provisioner "shell" {
     expect_disconnect = true
-    inline = [
-      "sudo rm -fr /etc/ssh/*host*key*"
-    ]
-    only = [
-      "hyperv-iso.almalinux-9"
-    ]
+    inline            = ["sudo rm -fr /etc/ssh/*host*key*"]
+    only              = ["hyperv-iso.almalinux-9"]
   }
 
   post-processors {
@@ -270,9 +260,10 @@ build {
       compression_level = "9"
       output            = "AlmaLinux-9-Vagrant-{{.Provider}}-${var.os_ver_9}-${formatdate("YYYYMMDD", timestamp())}.x86_64.box"
       only = [
-        "sources.virtualbox-iso.almalinux-9",
-        "sources.vmware-iso.almalinux-9",
-        "sources.parallels-iso.almalinux-9",
+        "virtualbox-iso.almalinux-9",
+        "hyperv-iso.almalinux-9",
+        "vmware-iso.almalinux-9",
+        "parallels-iso.almalinux-9",
       ]
     }
 
@@ -280,9 +271,9 @@ build {
       compression_level = "9"
       output            = "AlmaLinux-9-Vagrant-{{.Provider}}-${var.os_ver_9}-${formatdate("YYYYMMDD", timestamp())}.aarch64.box"
       only = [
-        "sources.virtualbox-iso.almalinux-9-aarch64",
-        "sources.vmware-iso.almalinux-9-aarch64",
-        "sources.parallels-iso.almalinux-9-aarch64"
+        "virtualbox-iso.almalinux-9-aarch64",
+        "vmware-iso.almalinux-9-aarch64",
+        "parallels-iso.almalinux-9-aarch64",
       ]
     }
 
@@ -290,9 +281,7 @@ build {
       compression_level    = "9"
       vagrantfile_template = "tpl/vagrant/vagrantfile-libvirt.rb"
       output               = "AlmaLinux-9-Vagrant-{{.Provider}}-${var.os_ver_9}-${formatdate("YYYYMMDD", timestamp())}.x86_64.box"
-      only = [
-        "qemu.almalinux-9"
-      ]
+      only                 = ["qemu.almalinux-9"]
     }
   }
 }

--- a/almalinux_8_ami.pkr.hcl
+++ b/almalinux_8_ami.pkr.hcl
@@ -35,8 +35,8 @@ source "amazon-ebssurrogate" "almalinux_8_ami_x86_64" {
   ami_virtualization_type = "hvm"
   ami_regions             = var.aws_ami_regions
   tags = {
-    Name         = "${local.aws_ami_name_x86_64_8}",
-    Version      = "${local.aws_ami_version_8}",
+    Name         = "${local.aws_ami_name_x86_64_8}"
+    Version      = "${local.aws_ami_version_8}"
     Architecture = "x86_64"
   }
   boot_mode    = "uefi-preferred"
@@ -74,8 +74,8 @@ source "amazon-ebssurrogate" "almalinux_8_ami_aarch64" {
   ami_virtualization_type = "hvm"
   ami_regions             = var.aws_ami_regions
   tags = {
-    Name         = "${local.aws_ami_name_aarch64_8}",
-    Version      = "${local.aws_ami_version_8}",
+    Name         = "${local.aws_ami_name_aarch64_8}"
+    Version      = "${local.aws_ami_version_8}"
     Architecture = "aarch64"
   }
   imds_support  = "v2.0"
@@ -100,18 +100,21 @@ source "amazon-ebssurrogate" "almalinux_8_ami_aarch64" {
 
 build {
   sources = [
-    "sources.amazon-ebssurrogate.almalinux_8_ami_x86_64",
-    "sources.amazon-ebssurrogate.almalinux_8_ami_aarch64"
+    "source.amazon-ebssurrogate.almalinux_8_ami_x86_64",
+    "source.amazon-ebssurrogate.almalinux_8_ami_aarch64",
   ]
+
   provisioner "shell" {
     inline = ["sudo dnf -y install ansible-core dosfstools"]
   }
+
   provisioner "ansible-local" {
     playbook_dir  = "./ansible"
     playbook_file = "./ansible/ami_8_x86_64.yaml"
     galaxy_file   = "./ansible/requirements.yml"
     only          = ["amazon-ebssurrogate.almalinux_8_ami_x86_64"]
   }
+
   provisioner "ansible-local" {
     playbook_dir  = "./ansible"
     playbook_file = "./ansible/ami_8_aarch64.yaml"

--- a/almalinux_9_ami.pkr.hcl
+++ b/almalinux_9_ami.pkr.hcl
@@ -35,8 +35,8 @@ source "amazon-ebssurrogate" "almalinux_9_ami_x86_64" {
   ami_virtualization_type = "hvm"
   ami_regions             = var.aws_ami_regions
   tags = {
-    Name         = "${local.aws_ami_name_x86_64_9}",
-    Version      = "${local.aws_ami_version_9}",
+    Name         = "${local.aws_ami_name_x86_64_9}"
+    Version      = "${local.aws_ami_version_9}"
     Architecture = "x86_64"
   }
   boot_mode    = "uefi-preferred"
@@ -74,8 +74,8 @@ source "amazon-ebssurrogate" "almalinux_9_ami_aarch64" {
   ami_virtualization_type = "hvm"
   ami_regions             = var.aws_ami_regions
   tags = {
-    Name         = "${local.aws_ami_name_aarch64_9}",
-    Version      = "${local.aws_ami_version_9}",
+    Name         = "${local.aws_ami_name_aarch64_9}"
+    Version      = "${local.aws_ami_version_9}"
     Architecture = "aarch64"
   }
   imds_support  = "v2.0"
@@ -100,18 +100,21 @@ source "amazon-ebssurrogate" "almalinux_9_ami_aarch64" {
 
 build {
   sources = [
-    "sources.amazon-ebssurrogate.almalinux_9_ami_x86_64",
-    "sources.amazon-ebssurrogate.almalinux_9_ami_aarch64"
+    "source.amazon-ebssurrogate.almalinux_9_ami_x86_64",
+    "source.amazon-ebssurrogate.almalinux_9_ami_aarch64",
   ]
+
   provisioner "shell" {
     inline = ["sudo dnf -y install ansible-core dosfstools"]
   }
+
   provisioner "ansible-local" {
     playbook_dir  = "./ansible"
     playbook_file = "./ansible/ami_9_x86_64.yaml"
     galaxy_file   = "./ansible/requirements.yml"
     only          = ["amazon-ebssurrogate.almalinux_9_ami_x86_64"]
   }
+
   provisioner "ansible-local" {
     playbook_dir  = "./ansible"
     playbook_file = "./ansible/ami_9_aarch64.yaml"

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -176,7 +176,7 @@ local "gencloud_boot_command_8_x86_64" {
     "<enter>",
     "initrdefi /images/pxeboot/initrd.img",
     "<enter>",
-    "boot<enter><wait>"
+    "boot<enter><wait>",
   ]
 }
 
@@ -190,7 +190,7 @@ local "gencloud_boot_command_8_aarch64" {
     "<enter>",
     "initrd /images/pxeboot/initrd.img",
     "<enter>",
-    "boot<enter><wait>"
+    "boot<enter><wait>",
   ]
 }
 
@@ -204,7 +204,7 @@ local "gencloud_boot_command_8_ppc64le" {
     "<enter>",
     "initrd /ppc/ppc64/initrd.img",
     "<enter>",
-    "boot<enter><wait>"
+    "boot<enter><wait>",
   ]
 }
 
@@ -218,7 +218,7 @@ local "gencloud_boot_command_9_x86_64" {
     "<enter>",
     "initrdefi /images/pxeboot/initrd.img",
     "<enter>",
-    "boot<enter><wait>"
+    "boot<enter><wait>",
   ]
 }
 
@@ -231,7 +231,7 @@ local "gencloud_boot_command_9_aarch64" {
     " inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-9.gencloud-aarch64.ks",
     "<enter>",
     "initrd /images/pxeboot/initrd.img<enter>",
-    "boot<enter><wait>"
+    "boot<enter><wait>",
   ]
 }
 
@@ -244,7 +244,7 @@ local "gencloud_boot_command_9_ppc64le" {
     " inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-9.gencloud-ppc64le.ks",
     "<enter>",
     "initrd /ppc/ppc64/initrd.img<enter>",
-    "boot<enter><wait>"
+    "boot<enter><wait>",
   ]
 }
 
@@ -267,7 +267,7 @@ local "azure_boot_command_8_x86_64" {
     "<enter>",
     "initrdefi /images/pxeboot/initrd.img",
     "<enter>",
-    "boot<enter><wait>"
+    "boot<enter><wait>",
   ]
 }
 
@@ -281,7 +281,7 @@ local "azure_boot_command_9_x86_64" {
     "<enter>",
     "initrdefi /images/pxeboot/initrd.img",
     "<enter>",
-    "boot<enter><wait>"
+    "boot<enter><wait>",
   ]
 }
 
@@ -439,7 +439,7 @@ variable "vagrant_boot_command_8_x86_64_bios" {
   default = [
     "<tab>",
     " inst.text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-8.vagrant-x86_64-bios.ks",
-    "<enter><wait>"
+    "<enter><wait>",
   ]
 }
 
@@ -452,7 +452,7 @@ local "vagrant_boot_command_8_x86_64" {
     " inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-8.vagrant-x86_64.ks",
     "<enter>",
     "initrdefi /images/pxeboot/initrd.img<enter>",
-    "boot<enter><wait>"
+    "boot<enter><wait>",
   ]
 }
 
@@ -467,7 +467,7 @@ local "vagrant_boot_command_9_x86_64" {
     "<enter>",
     "initrdefi /images/pxeboot/initrd.img",
     "<enter>",
-    "boot<enter><wait>"
+    "boot<enter><wait>",
   ]
 }
 
@@ -478,7 +478,7 @@ variable "vagrant_boot_command_9_x86_64_bios" {
   default = [
     "<tab>",
     "inst.text inst.gpt inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-9.vagrant-x86_64-bios.ks",
-    "<enter><wait>"
+    "<enter><wait>",
   ]
 }
 
@@ -490,7 +490,7 @@ variable "vagrant_boot_command_9_aarch64" {
     "e",
     "<down><down><end><bs><bs><bs><bs><bs>",
     "inst.text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-9.vagrant-aarch64.ks",
-    "<leftCtrlOn>x<leftCtrlOff>"
+    "<leftCtrlOn>x<leftCtrlOff>",
   ]
 }
 


### PR DESCRIPTION
Fixes:

- The source names inside only and except of provision block should be without "source." prefix. The previous commit introduced "sources." prefix which broke the AlmaLinux OS 9.4 Vagrant boxes with ignoring entire provisioners and creating boxes without any configuration.

- Add "ANSIBLE_HOST_KEY_CHECKING=False" for AlmaLinux OS 9 Vagrant box for Hyper-V provider.
- Add "hyperv-iso.almalinux-9" to Vagrant post-processor.

Formatting:

These recent bugs also made me review the latest documentation of HCL2 for Packer.

These best practices applied to avoid any kind of this issue and have a consistency on all Packer templates.

- Use "source." prefix on all build blocks.
- Use trailing commas on multi-line HCL2 list types.
- Use native syntax for multi-line HCL2 map typse with replacing colon with equal and remove comma separator.
- Don't use any prefix for provision and post-processor blocks.

We started to write these Packer templates when the JSON to HCL2 transition was new. As HCL2 support on Packer evolves it got new features and core syntax is stabilized now.

These changes optimize all the templates regardless of when they are written.