### PR TITLE
fix(kickstart): create required partitions

### DIFF
--- a/http/almalinux-8.vagrant-x86_64-bios.ks
+++ b/http/almalinux-8.vagrant-x86_64-bios.ks
@@ -20,6 +20,7 @@ bootloader --timeout=0 --location=mbr --append="console=tty0 console=ttyS0,11520
 
 zerombr
 clearpart --all --initlabel
+reqpart
 part /boot --fstype=xfs --size=1024
 part / --fstype=xfs --grow
 

--- a/http/almalinux-9.vagrant-x86_64-bios.ks
+++ b/http/almalinux-9.vagrant-x86_64-bios.ks
@@ -20,6 +20,7 @@ bootloader --timeout=0 --location=mbr --append="console=tty0 console=ttyS0,11520
 
 zerombr
 clearpart --all --initlabel
+reqpart
 part /boot --fstype=xfs --size=1024
 part / --fstype=xfs --grow
 


### PR DESCRIPTION
When installing an BIOS system into GPT partition table, biosboot partition is needed as a first partition on the disk. Adding reqpart to the kickstart file of BIOS versions of the kickstart files, tells Anaconda Installer to automatically create partitions required by the hardware platform.

This fixes error on Anaconda Installer due the partitioning.