### PR TITLE
feat(ansible): make kernel options dynamic

### DIFF
--- a/ansible/azure.yml
+++ b/ansible/azure.yml
@@ -6,6 +6,8 @@
 
   roles:
     - role: unified_boot
+      vars:
+        unified_boot_kernel_opts: loglevel=3 console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300 no_timer_check biosdevname=0 net.ifnames=0
       when: is_unified_boot is defined
     - azure_guest
     - cleanup_vm

--- a/ansible/roles/unified_boot/defaults/main.yaml
+++ b/ansible/roles/unified_boot/defaults/main.yaml
@@ -1,0 +1,2 @@
+---
+unified_boot_kernel_opts: console=tty0 console=ttyS0,115200n8 no_timer_check biosdevname=0 net.ifnames=0

--- a/ansible/roles/unified_boot/tasks/main.yaml
+++ b/ansible/roles/unified_boot/tasks/main.yaml
@@ -76,7 +76,7 @@
     cmd: >
       grub2-editenv -v - set
       kernelopts="root=UUID={{ root_uuid.stdout }}
-      console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0"
+      {{ unified_boot_kernel_opts }}"
       saved_entry={{ machine_id }}-{{ kernel_ver.stdout }}
     creates: /boot/grub2/grubenv
 


### PR DESCRIPTION
ansible/roles/unified_boot:
- Since AlmaLinux OS 8 Azure VM image for x86_64 uses different kernel options than the generic one we set for others,
make it dynamic with unified_boot_kernel_opts ansible variable.

- Add biosdevname=0 to default value of unified_boot_kernel_opts ansible role variable to be consistent with GRUB_CMDLINE_LINUX in /etc/default/grub