### PR TITLE
feat: use memory limits as default

### DIFF
--- a/almalinux-8-azure.pkr.hcl
+++ b/almalinux-8-azure.pkr.hcl
@@ -19,7 +19,7 @@ source "qemu" "almalinux-8-azure-x86_64" {
   format             = "raw"
   headless           = var.headless
   machine_type       = "q35"
-  memory             = var.memory
+  memory             = var.memory_x86_64
   net_device         = "virtio-net"
   qemu_binary        = var.qemu_binary
   vm_name            = "AlmaLinux-8-Azure-${var.os_ver_8}-${formatdate("YYYYMMDD", timestamp())}.x86_64.raw"

--- a/almalinux-8-digitalocean.pkr.hcl
+++ b/almalinux-8-digitalocean.pkr.hcl
@@ -20,7 +20,7 @@ source "qemu" "almalinux-8-digitalocean-x86_64" {
   format             = "qcow2"
   headless           = var.headless
   machine_type       = "q35"
-  memory             = var.memory
+  memory             = var.memory_x86_64
   net_device         = "virtio-net"
   qemu_binary        = var.qemu_binary
   vm_name            = "AlmaLinux-8-DigitalOcean-${var.os_ver_8}-${formatdate("YYYYMMDD", timestamp())}.x86_64.qcow2"

--- a/almalinux-8-gencloud.pkr.hcl
+++ b/almalinux-8-gencloud.pkr.hcl
@@ -20,7 +20,7 @@ source "qemu" "almalinux-8-gencloud-x86_64" {
   format             = "qcow2"
   headless           = var.headless
   machine_type       = "q35"
-  memory             = var.memory
+  memory             = var.memory_x86_64
   net_device         = "virtio-net"
   qemu_binary        = var.qemu_binary
   vm_name            = "AlmaLinux-8-GenericCloud-${var.os_ver_8}-${formatdate("YYYYMMDD", timestamp())}.x86_64.qcow2"
@@ -54,7 +54,7 @@ source "qemu" "almalinux-8-gencloud-aarch64" {
   format             = "qcow2"
   headless           = var.headless
   machine_type       = "virt,gic-version=max"
-  memory             = var.memory
+  memory             = var.memory_aarch64
   net_device         = "virtio-net"
   qemu_binary        = var.qemu_binary
   vm_name            = "AlmaLinux-8-GenericCloud-${var.os_ver_8}-${formatdate("YYYYMMDD", timestamp())}.aarch64.qcow2"
@@ -85,7 +85,7 @@ source "qemu" "almalinux-8-gencloud-ppc64le" {
   format             = "qcow2"
   headless           = var.headless
   machine_type       = "pseries,accel=kvm,kvm-type=HV"
-  memory             = var.memory
+  memory             = var.memory_ppc64le
   net_device         = "virtio-net"
   qemu_binary        = var.qemu_binary
   vm_name            = "AlmaLinux-8-GenericCloud-${var.os_ver_8}-${formatdate("YYYYMMDD", timestamp())}.ppc64le.qcow2"

--- a/almalinux-8-oci.pkr.hcl
+++ b/almalinux-8-oci.pkr.hcl
@@ -20,7 +20,7 @@ source "qemu" "almalinux-8-oci-x86_64" {
   format             = "qcow2"
   headless           = var.headless
   machine_type       = "q35"
-  memory             = var.memory
+  memory             = var.memory_x86_64
   net_device         = "virtio-net"
   qemu_binary        = var.qemu_binary
   vm_name            = "AlmaLinux-8-OCI-${var.os_ver_8}-${formatdate("YYYYMMDD", timestamp())}.x86_64.qcow2"
@@ -54,7 +54,7 @@ source "qemu" "almalinux-8-oci-aarch64" {
   format             = "qcow2"
   headless           = var.headless
   machine_type       = "virt,gic-version=max"
-  memory             = var.memory
+  memory             = var.memory_aarch64
   net_device         = "virtio-net"
   qemu_binary        = var.qemu_binary
   vm_name            = "AlmaLinux-8-OCI-${var.os_ver_8}-${formatdate("YYYYMMDD", timestamp())}.aarch64.qcow2"

--- a/almalinux-8-opennebula.pkr.hcl
+++ b/almalinux-8-opennebula.pkr.hcl
@@ -20,7 +20,7 @@ source "qemu" "almalinux-8-opennebula-x86_64" {
   format             = "qcow2"
   headless           = var.headless
   machine_type       = "q35"
-  memory             = var.memory
+  memory             = var.memory_x86_64
   net_device         = "virtio-net"
   qemu_binary        = var.qemu_binary
   vm_name            = "AlmaLinux-8-OpenNebula-${var.os_ver_8}-${formatdate("YYYYMMDD", timestamp())}.x86_64.qcow2"
@@ -54,7 +54,7 @@ source "qemu" "almalinux-8-opennebula-aarch64" {
   format             = "qcow2"
   headless           = var.headless
   machine_type       = "virt,gic-version=max"
-  memory             = var.memory
+  memory             = var.memory_aarch64
   net_device         = "virtio-net"
   qemu_binary        = var.qemu_binary
   vm_name            = "AlmaLinux-8-OpenNebula-${var.os_ver_8}-${formatdate("YYYYMMDD", timestamp())}.aarch64.qcow2"

--- a/almalinux-8-vagrant.pkr.hcl
+++ b/almalinux-8-vagrant.pkr.hcl
@@ -20,7 +20,7 @@ source "qemu" "almalinux-8" {
   format             = "qcow2"
   headless           = var.headless
   machine_type       = "q35"
-  memory             = var.memory
+  memory             = var.memory_x86_64
   net_device         = "virtio-net"
   qemu_binary        = var.qemu_binary
   vm_name            = "AlmaLinux-8-Vagrant-Libvirt-${var.os_ver_8}-${formatdate("YYYYMMDD", timestamp())}.x86_64.qcow2"
@@ -46,7 +46,7 @@ source "virtualbox-iso" "almalinux-8" {
   disk_size            = var.vagrant_disk_size
   guest_os_type        = "RedHat_64"
   cpus                 = var.cpus
-  memory               = var.memory
+  memory               = var.memory_x86_64
   headless             = var.headless
   hard_drive_interface = "sata"
   iso_interface        = "sata"
@@ -70,7 +70,7 @@ source "hyperv-iso" "almalinux-8" {
   boot_wait             = var.boot_wait
   disk_size             = var.vagrant_disk_size
   disk_block_size       = 1
-  memory                = var.memory
+  memory                = var.memory_x86_64
   switch_name           = var.hyperv_switch_name
   cpus                  = var.cpus
   generation            = 2
@@ -91,7 +91,7 @@ source "vmware-iso" "almalinux-8" {
   disk_size                      = var.vagrant_disk_size
   guest_os_type                  = "centos-64"
   cpus                           = var.cpus
-  memory                         = var.memory
+  memory                         = var.memory_x86_64
   headless                       = var.headless
   vmx_remove_ethernet_interfaces = true
   vmx_data = {
@@ -116,7 +116,7 @@ source "parallels-iso" "almalinux-8" {
   cpus                   = var.cpus
   disk_size              = var.vagrant_disk_size
   guest_os_type          = "centos"
-  memory                 = var.memory
+  memory                 = var.memory_x86_64
   parallels_tools_flavor = var.parallels_tools_flavor_x86_64
 }
 

--- a/almalinux-9-azure.pkr.hcl
+++ b/almalinux-9-azure.pkr.hcl
@@ -19,7 +19,7 @@ source "qemu" "almalinux-9-azure-x86_64" {
   format             = "raw"
   headless           = var.headless
   machine_type       = "q35"
-  memory             = var.memory
+  memory             = var.memory_x86_64
   net_device         = "virtio-net"
   qemu_binary        = var.qemu_binary
   vm_name            = "AlmaLinux-9-Azure-${var.os_ver_9}-${formatdate("YYYYMMDD", timestamp())}.x86_64.raw"

--- a/almalinux-9-digitalocean.pkr.hcl
+++ b/almalinux-9-digitalocean.pkr.hcl
@@ -20,7 +20,7 @@ source "qemu" "almalinux-9-digitalocean-x86_64" {
   format             = "qcow2"
   headless           = var.headless
   machine_type       = "q35"
-  memory             = var.memory
+  memory             = var.memory_x86_64
   net_device         = "virtio-net"
   qemu_binary        = var.qemu_binary
   vm_name            = "AlmaLinux-9-DigitalOcean-${var.os_ver_9}-${formatdate("YYYYMMDD", timestamp())}.x86_64.qcow2"

--- a/almalinux-9-gencloud.pkr.hcl
+++ b/almalinux-9-gencloud.pkr.hcl
@@ -20,7 +20,7 @@ source "qemu" "almalinux-9-gencloud-x86_64" {
   format             = "qcow2"
   headless           = var.headless
   machine_type       = "q35"
-  memory             = var.memory
+  memory             = var.memory_x86_64
   net_device         = "virtio-net"
   qemu_binary        = var.qemu_binary
   vm_name            = "AlmaLinux-9-GenericCloud-${var.os_ver_9}-${formatdate("YYYYMMDD", timestamp())}.x86_64.qcow2"
@@ -54,7 +54,7 @@ source "qemu" "almalinux-9-gencloud-aarch64" {
   format             = "qcow2"
   headless           = var.headless
   machine_type       = "virt,gic-version=max"
-  memory             = var.memory
+  memory             = var.memory_aarch64
   net_device         = "virtio-net"
   qemu_binary        = var.qemu_binary
   vm_name            = "AlmaLinux-9-GenericCloud-${var.os_ver_9}-${formatdate("YYYYMMDD", timestamp())}.aarch64.qcow2"
@@ -85,7 +85,7 @@ source "qemu" "almalinux-9-gencloud-ppc64le" {
   format             = "qcow2"
   headless           = var.headless
   machine_type       = "pseries,accel=kvm,kvm-type=HV"
-  memory             = var.memory
+  memory             = var.memory_ppc64le
   net_device         = "virtio-net"
   qemu_binary        = var.qemu_binary
   vm_name            = "AlmaLinux-9-GenericCloud-${var.os_ver_9}-${formatdate("YYYYMMDD", timestamp())}.ppc64le.qcow2"

--- a/almalinux-9-oci.pkr.hcl
+++ b/almalinux-9-oci.pkr.hcl
@@ -20,7 +20,7 @@ source "qemu" "almalinux-9-oci-x86_64" {
   format             = "qcow2"
   headless           = var.headless
   machine_type       = "q35"
-  memory             = var.memory
+  memory             = var.memory_x86_64
   net_device         = "virtio-net"
   qemu_binary        = var.qemu_binary
   vm_name            = "AlmaLinux-9-OCI-${var.os_ver_9}-${formatdate("YYYYMMDD", timestamp())}.x86_64.qcow2"
@@ -54,7 +54,7 @@ source "qemu" "almalinux-9-oci-aarch64" {
   format             = "qcow2"
   headless           = var.headless
   machine_type       = "virt,gic-version=max"
-  memory             = var.memory
+  memory             = var.memory_aarch64
   net_device         = "virtio-net"
   qemu_binary        = var.qemu_binary
   vm_name            = "AlmaLinux-9-OCI-${var.os_ver_9}-${formatdate("YYYYMMDD", timestamp())}.aarch64.qcow2"

--- a/almalinux-9-opennebula.pkr.hcl
+++ b/almalinux-9-opennebula.pkr.hcl
@@ -20,7 +20,7 @@ source "qemu" "almalinux-9-opennebula-x86_64" {
   format             = "qcow2"
   headless           = var.headless
   machine_type       = "q35"
-  memory             = var.memory
+  memory             = var.memory_x86_64
   net_device         = "virtio-net"
   qemu_binary        = var.qemu_binary
   vm_name            = "AlmaLinux-9-OpenNebula-${var.os_ver_9}-${formatdate("YYYYMMDD", timestamp())}.x86_64.qcow2"
@@ -54,7 +54,7 @@ source "qemu" "almalinux-9-opennebula-aarch64" {
   format             = "qcow2"
   headless           = var.headless
   machine_type       = "virt,gic-version=max"
-  memory             = var.memory
+  memory             = var.memory_aarch64
   net_device         = "virtio-net"
   qemu_binary        = var.qemu_binary
   vm_name            = "AlmaLinux-9-OpenNebula-${var.os_ver_9}-${formatdate("YYYYMMDD", timestamp())}.aarch64.qcow2"

--- a/almalinux-9-vagrant.pkr.hcl
+++ b/almalinux-9-vagrant.pkr.hcl
@@ -20,7 +20,7 @@ source "qemu" "almalinux-9" {
   format             = "qcow2"
   headless           = var.headless
   machine_type       = "q35"
-  memory             = var.memory
+  memory             = var.memory_x86_64
   net_device         = "virtio-net"
   qemu_binary        = var.qemu_binary
   vm_name            = "AlmaLinux-9-Vagrant-Libvirt-${var.os_ver_9}-${formatdate("YYYYMMDD", timestamp())}.x86_64.qcow2"
@@ -46,7 +46,7 @@ source "virtualbox-iso" "almalinux-9" {
   disk_size            = var.vagrant_disk_size
   guest_os_type        = "RedHat_64"
   cpus                 = var.cpus
-  memory               = var.memory
+  memory               = var.memory_x86_64
   headless             = var.headless
   hard_drive_interface = "sata"
   iso_interface        = "sata"
@@ -70,7 +70,7 @@ source "hyperv-iso" "almalinux-9" {
   boot_wait             = var.boot_wait
   disk_size             = var.vagrant_disk_size
   disk_block_size       = 1
-  memory                = var.memory
+  memory                = var.memory_x86_64
   switch_name           = var.hyperv_switch_name
   cpus                  = var.cpus
   generation            = 2
@@ -91,7 +91,7 @@ source "vmware-iso" "almalinux-9" {
   disk_size                      = var.vagrant_disk_size
   guest_os_type                  = "centos-64"
   cpus                           = var.cpus
-  memory                         = var.memory
+  memory                         = var.memory_x86_64
   headless                       = var.headless
   vmx_remove_ethernet_interfaces = true
   vmx_data = {
@@ -116,7 +116,7 @@ source "parallels-iso" "almalinux-9" {
   cpus                   = var.cpus
   disk_size              = var.vagrant_disk_size
   guest_os_type          = "centos"
-  memory                 = var.memory
+  memory                 = var.memory_x86_64
   parallels_tools_flavor = var.parallels_tools_flavor_x86_64
 }
 
@@ -133,7 +133,7 @@ source "vmware-iso" "almalinux-9-aarch64" {
   disk_size                      = var.vagrant_disk_size
   guest_os_type                  = "arm-rhel9-64"
   cpus                           = var.cpus
-  memory                         = var.memory
+  memory                         = var.memory_aarch64
   headless                       = var.headless
   vmx_remove_ethernet_interfaces = true
   vm_name                        = "almalinux-9"
@@ -162,7 +162,7 @@ source "parallels-iso" "almalinux-9-aarch64" {
   cpus                   = var.cpus
   disk_size              = var.vagrant_disk_size
   guest_os_type          = "centos"
-  memory                 = var.memory
+  memory                 = var.memory_aarch64
   parallels_tools_flavor = var.parallels_tools_flavor_aarch64
 }
 
@@ -179,7 +179,7 @@ source "virtualbox-iso" "almalinux-9-aarch64" {
   disk_size            = var.vagrant_disk_size
   guest_os_type        = "RedHat_64"
   cpus                 = var.cpus
-  memory               = var.memory
+  memory               = var.memory_aarch64
   headless             = var.headless
   hard_drive_interface = "sata"
   vboxmanage           = [["modifyvm", "{{.Name}}", "--nat-localhostreachable1", "on"]]

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -65,11 +65,25 @@ variable "cpus" {
   default = 2
 }
 
-variable "memory" {
-  description = "The amount of memory"
+variable "memory_x86_64" {
+  description = "The amount of memory to use when building the x86_64 VM in megabytes"
 
   type    = number
-  default = 2048
+  default = 3072
+}
+
+variable "memory_aarch64" {
+  description = "The amount of memory to use when building the AArch64 VM in megabytes"
+
+  type    = number
+  default = 4096
+}
+
+variable "memory_ppc64le" {
+  description = "The amount of memory to use when building the ppc64le VM in megabytes"
+
+  type    = number
+  default = 4096
 }
 
 variable "post_cpus" {


### PR DESCRIPTION
The amounts of minimum required memory for network installations over HTTPS is documented as:
- 3 GiB for x86_64.
- 4 GiB for AArch64.
- 4 GiB for ppc64le.
- 3 GiB for s390x.

Instead of using 2 GiB for the all architectures,
let's relay on more precise installation method and architecture specific required memory sizes to be safe from any possible crashes.

See: https://access.redhat.com/articles/rhel-limits#minimum-required-memory-3