### PR TITLE
feat(vmware): enhancements for vagrant boxes

### DIFF
--- a/almalinux-8-vagrant.pkr.hcl
+++ b/almalinux-8-vagrant.pkr.hcl
@@ -86,12 +86,16 @@ source "vmware-iso" "almalinux-8" {
   ssh_username                   = var.vagrant_ssh_username
   ssh_password                   = var.vagrant_ssh_password
   ssh_timeout                    = var.ssh_timeout
-  boot_command                   = var.vagrant_boot_command_8_x86_64_bios
+  boot_command                   = local.vagrant_boot_command_8_x86_64
   boot_wait                      = var.boot_wait
   disk_size                      = var.vagrant_disk_size
   guest_os_type                  = "centos-64"
+  version                        = 21
+  vm_name                        = "AlmaLinux-8-Vagrant-VMware-${var.os_ver_8}-${formatdate("YYYYMMDD", timestamp())}.x86_64"
+  firmware                       = "efi"
   cpus                           = var.cpus
   memory                         = var.memory_x86_64
+  network_adapter_type           = "vmxnet3"
   headless                       = var.headless
   vmx_remove_ethernet_interfaces = true
   vmx_data = {
@@ -147,6 +151,7 @@ build {
     only = [
       "qemu.almalinux-8",
       "virtualbox-iso.almalinux-8",
+      "vmware-iso.almalinux-8",
     ]
   }
 
@@ -192,10 +197,7 @@ build {
       "--extra-vars",
       "packer_provider=${source.type}",
     ]
-    only = [
-      "vmware-iso.almalinux-8",
-      "parallels-iso.almalinux-8",
-    ]
+    only = ["parallels-iso.almalinux-8"]
   }
 
   post-processors {

--- a/almalinux-9-vagrant.pkr.hcl
+++ b/almalinux-9-vagrant.pkr.hcl
@@ -86,12 +86,16 @@ source "vmware-iso" "almalinux-9" {
   ssh_username                   = var.vagrant_ssh_username
   ssh_password                   = var.vagrant_ssh_password
   ssh_timeout                    = var.ssh_timeout
-  boot_command                   = var.vagrant_boot_command_9_x86_64_bios
+  boot_command                   = local.vagrant_boot_command_9_x86_64
   boot_wait                      = var.boot_wait
   disk_size                      = var.vagrant_disk_size
   guest_os_type                  = "centos-64"
+  version                        = 21
+  vm_name                        = "AlmaLinux-9-Vagrant-VMware-${var.os_ver_9}-${formatdate("YYYYMMDD", timestamp())}.x86_64"
+  firmware                       = "efi"
   cpus                           = var.cpus
   memory                         = var.memory_x86_64
+  network_adapter_type           = "vmxnet3"
   headless                       = var.headless
   vmx_remove_ethernet_interfaces = true
   vmx_data = {
@@ -132,21 +136,16 @@ source "vmware-iso" "almalinux-9-aarch64" {
   boot_wait                      = var.boot_wait
   disk_size                      = var.vagrant_disk_size
   guest_os_type                  = "arm-rhel9-64"
+  version                        = 21
+  vm_name                        = "AlmaLinux-9-Vagrant-VMware-${var.os_ver_9}-${formatdate("YYYYMMDD", timestamp())}.aarch64"
+  firmware                       = "efi"
   cpus                           = var.cpus
   memory                         = var.memory_aarch64
+  network_adapter_type           = "vmxnet3"
   headless                       = var.headless
   vmx_remove_ethernet_interfaces = true
-  vm_name                        = "almalinux-9"
   usb                            = true
   disk_adapter_type              = "nvme"
-  vmx_data = {
-    ".encoding"            = "UTF-8"
-    "config.version"       = "8"
-    "virtualHW.version"    = "20"
-    "usb_xhci.present"     = "true"
-    "ethernet0.virtualdev" = "e1000e"
-    "firmware"             = "efi"
-  }
 }
 
 source "parallels-iso" "almalinux-9-aarch64" {

--- a/versions.pkr.hcl
+++ b/versions.pkr.hcl
@@ -34,7 +34,7 @@ packer {
       source  = "github.com/hashicorp/virtualbox"
     }
     vmware = {
-      version = ">= 1.0.6"
+      version = ">= 1.1.0"
       source  = "github.com/hashicorp/vmware"
     }
   }


### PR DESCRIPTION
Bump the minimum required version of VMware Packer plugin from 1.0.6 to 1.1.0 which introduces UEFI and Secure Boot support.

- AlmaLinux OS 9 and 8 x86_64 Vagrant boxes for vmware_desktop provider now supports unified boot (BIOS and UEFI) now.
- Replace "firmware" = "efi" vmx_data option with the a Packer-native option for AlmaLinux OS 9 AArch64 Vagrant boxes
for vmware_desktop provider.

Use VMXNET Generation 3 (VMXNET3) as network adapter which is the latest, yields the best performance and compatible so included on AlmaLinux OS kernel.

- Replace "ethernet0.virtualdev" = "e1000e" vmx_data option with the a Packer-native option for AlmaLinux OS 9 AArch64 Vagrant boxes for vmware_desktop provider.

Bump the VMware Virtual machine hardware version from 9 to the 21 which the latest. Since the all the desktop VMware products are free now, adoption of the latest version will be faster which will eventually make users to want to use all the latest features of the latest hardware version.

- Replace "virtualHW.version" = "20" vmx_data option with a Packer-native option for AlmaLinux OS 9 AArch64 Vagrant boxes for vmware_desktop provider. This will fix the warning on the output of Packer validate. Which will unblock of using GitHub Actions like automation for validation of Packer templates on each Pull Request.

Drop the vmx_data usage for AlmaLinux OS 9 AArch64 Vagrant boxes for vmware_desktop provider. Since we are able to use the Packer-native options of these vmx_data one:
- "ethernet0.virtualdev" = "e1000e"
- "firmware"             = "efi"

The other vmx_data options are not necessary neither during building nor running.


See: https://github.com/hashicorp/packer-plugin-vmware/pull/212