### PR TITLE
feat(aws): add support for copying tags

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-boto3>=1.34.62
-markdown-table==2020.12.3
 pytest-testinfra>=10.1.0
 paramiko>=3.4.0
 pyyaml>=6.0.1

--- a/tools/aws_ami_mirror.py
+++ b/tools/aws_ami_mirror.py
@@ -207,6 +207,7 @@ def copy_ami(ami_info, src_region, dst_region, aws_client_token):
         Name=ami_info["Name"],
         SourceImageId=ami_info["ImageId"],
         SourceRegion=src_region,
+        CopyImageTags=True,
     )
     dst_ami_id = resp["ImageId"]
     log.info(f"uploading {dst_ami_id} to {dst_region}")

--- a/tools/requirements-aws.txt
+++ b/tools/requirements-aws.txt
@@ -1,0 +1,2 @@
+boto3>=1.34.62
+markdown-table==2020.12.3


### PR DESCRIPTION
Starting with the 1.26.13 version of boto3, it possible to copy tags of the Amazon Machine Images. Add this support to our AMI mirror tool too to be able to copy the tags
on the original AMIs such as:
- Name: AlmaLinux OS 9.5.20241122 x86_64
- Version: 9.5.20241122
- Architecture: x86_64