### PR TITLE
chore(9): refactor packer boot commands

### DIFF
--- a/almalinux-9-azure.pkr.hcl
+++ b/almalinux-9-azure.pkr.hcl
@@ -8,7 +8,7 @@ source "qemu" "almalinux-9-azure-x86_64" {
   ssh_username       = var.gencloud_ssh_username
   ssh_password       = var.gencloud_ssh_password
   ssh_timeout        = var.ssh_timeout
-  boot_command       = local.azure_boot_command_9_x86_64
+  boot_command       = var.azure_boot_command_9_x86_64
   boot_wait          = var.boot_wait
   accelerator        = "kvm"
   disk_interface     = "virtio-scsi"

--- a/almalinux-9-digitalocean.pkr.hcl
+++ b/almalinux-9-digitalocean.pkr.hcl
@@ -8,7 +8,7 @@ source "qemu" "almalinux-9-digitalocean-x86_64" {
   ssh_username       = var.gencloud_ssh_username
   ssh_password       = var.gencloud_ssh_password
   ssh_timeout        = var.ssh_timeout
-  boot_command       = local.gencloud_boot_command_9_x86_64
+  boot_command       = var.gencloud_boot_command_9_x86_64
   boot_wait          = var.boot_wait
   accelerator        = "kvm"
   disk_interface     = "virtio-scsi"

--- a/almalinux-9-gencloud.pkr.hcl
+++ b/almalinux-9-gencloud.pkr.hcl
@@ -8,7 +8,7 @@ source "qemu" "almalinux-9-gencloud-x86_64" {
   ssh_username       = var.gencloud_ssh_username
   ssh_password       = var.gencloud_ssh_password
   ssh_timeout        = var.ssh_timeout
-  boot_command       = local.gencloud_boot_command_9_x86_64
+  boot_command       = var.gencloud_boot_command_9_x86_64
   boot_wait          = var.boot_wait
   accelerator        = "kvm"
   disk_interface     = "virtio-scsi"
@@ -40,7 +40,7 @@ source "qemu" "almalinux-9-gencloud-aarch64" {
   ssh_username       = var.gencloud_ssh_username
   ssh_password       = var.gencloud_ssh_password
   ssh_timeout        = var.ssh_timeout
-  boot_command       = local.gencloud_boot_command_9_aarch64
+  boot_command       = var.gencloud_boot_command_9_aarch64
   boot_wait          = var.boot_wait
   accelerator        = "kvm"
   firmware           = var.aavmf_code
@@ -74,7 +74,7 @@ source "qemu" "almalinux-9-gencloud-ppc64le" {
   ssh_username       = var.gencloud_ssh_username
   ssh_password       = var.gencloud_ssh_password
   ssh_timeout        = var.ssh_timeout
-  boot_command       = local.gencloud_boot_command_9_ppc64le
+  boot_command       = var.gencloud_boot_command_9_ppc64le
   boot_wait          = var.gencloud_boot_wait_ppc64le
   disk_interface     = "virtio-scsi"
   disk_size          = var.gencloud_disk_size

--- a/almalinux-9-oci.pkr.hcl
+++ b/almalinux-9-oci.pkr.hcl
@@ -8,7 +8,7 @@ source "qemu" "almalinux-9-oci-x86_64" {
   ssh_username       = var.gencloud_ssh_username
   ssh_password       = var.gencloud_ssh_password
   ssh_timeout        = var.ssh_timeout
-  boot_command       = local.gencloud_boot_command_9_x86_64
+  boot_command       = var.gencloud_boot_command_9_x86_64
   boot_wait          = var.boot_wait
   accelerator        = "kvm"
   disk_interface     = "virtio-scsi"
@@ -40,7 +40,7 @@ source "qemu" "almalinux-9-oci-aarch64" {
   ssh_username       = var.gencloud_ssh_username
   ssh_password       = var.gencloud_ssh_password
   ssh_timeout        = var.ssh_timeout
-  boot_command       = local.gencloud_boot_command_9_aarch64
+  boot_command       = var.gencloud_boot_command_9_aarch64
   boot_wait          = var.boot_wait
   accelerator        = "kvm"
   firmware           = var.aavmf_code

--- a/almalinux-9-opennebula.pkr.hcl
+++ b/almalinux-9-opennebula.pkr.hcl
@@ -8,7 +8,7 @@ source "qemu" "almalinux-9-opennebula-x86_64" {
   ssh_username       = var.gencloud_ssh_username
   ssh_password       = var.gencloud_ssh_password
   ssh_timeout        = var.ssh_timeout
-  boot_command       = local.gencloud_boot_command_9_x86_64
+  boot_command       = var.gencloud_boot_command_9_x86_64
   boot_wait          = var.boot_wait
   accelerator        = "kvm"
   disk_interface     = "virtio-scsi"
@@ -40,7 +40,7 @@ source "qemu" "almalinux-9-opennebula-aarch64" {
   ssh_username       = var.gencloud_ssh_username
   ssh_password       = var.gencloud_ssh_password
   ssh_timeout        = var.ssh_timeout
-  boot_command       = local.gencloud_boot_command_9_aarch64
+  boot_command       = var.gencloud_boot_command_9_aarch64
   boot_wait          = var.boot_wait
   accelerator        = "kvm"
   firmware           = var.aavmf_code

--- a/almalinux-9-vagrant.pkr.hcl
+++ b/almalinux-9-vagrant.pkr.hcl
@@ -8,7 +8,7 @@ source "qemu" "almalinux-9" {
   ssh_username       = var.vagrant_ssh_username
   ssh_password       = var.vagrant_ssh_password
   ssh_timeout        = var.ssh_timeout
-  boot_command       = local.vagrant_boot_command_9_x86_64
+  boot_command       = var.vagrant_boot_command_9_x86_64
   boot_wait          = var.boot_wait
   accelerator        = "kvm"
   disk_interface     = "virtio-scsi"
@@ -40,7 +40,7 @@ source "virtualbox-iso" "almalinux-9" {
   ssh_username         = var.vagrant_ssh_username
   ssh_password         = var.vagrant_ssh_password
   ssh_timeout          = var.ssh_timeout
-  boot_command         = local.vagrant_boot_command_9_x86_64
+  boot_command         = var.vagrant_boot_command_9_x86_64
   boot_wait            = var.boot_wait
   firmware             = "efi"
   disk_size            = var.vagrant_disk_size
@@ -66,7 +66,7 @@ source "hyperv-iso" "almalinux-9" {
   ssh_username          = var.vagrant_ssh_username
   ssh_password          = var.vagrant_ssh_password
   ssh_timeout           = var.ssh_timeout
-  boot_command          = local.vagrant_boot_command_9_x86_64
+  boot_command          = var.vagrant_boot_command_9_x86_64
   boot_wait             = var.boot_wait
   disk_size             = var.vagrant_disk_size
   disk_block_size       = 1
@@ -86,7 +86,7 @@ source "vmware-iso" "almalinux-9" {
   ssh_username                   = var.vagrant_ssh_username
   ssh_password                   = var.vagrant_ssh_password
   ssh_timeout                    = var.ssh_timeout
-  boot_command                   = local.vagrant_boot_command_9_x86_64
+  boot_command                   = var.vagrant_boot_command_9_x86_64
   boot_wait                      = var.boot_wait
   disk_size                      = var.vagrant_disk_size
   guest_os_type                  = "centos-64"

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -24,7 +24,6 @@ variable "os_ver_9" {
 
 locals {
   os_ver_minor_8 = split(".", var.os_ver_8)[1]
-  os_ver_minor_9 = split(".", var.os_ver_9)[1]
 }
 
 locals {
@@ -222,43 +221,65 @@ local "gencloud_boot_command_8_ppc64le" {
   ]
 }
 
-local "gencloud_boot_command_9_x86_64" {
-  expression = [
-    "c<wait>",
-    "linuxefi /images/pxeboot/vmlinuz",
-    " inst.stage2=hd:LABEL=AlmaLinux-9-${local.os_ver_minor_9}-x86_64-dvd ro",
-    " inst.text biosdevname=0 net.ifnames=0",
-    " inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-9.gencloud-x86_64.ks",
-    "<enter>",
-    "initrdefi /images/pxeboot/initrd.img",
-    "<enter>",
-    "boot<enter><wait>",
+variable "gencloud_boot_command_9_x86_64" {
+  description = "Boot command for AlmaLinux OS 9 Generic Cloud x86_64"
+
+  type = list(string)
+  default = [
+    "e",
+    "<down><down>",
+    "<leftCtrlOn>e<leftCtrlOff>",
+    "<spacebar>",
+    "biosdevname=0",
+    "<spacebar>",
+    "net.ifnames=0",
+    "<spacebar>",
+    "inst.text",
+    "<spacebar>",
+    "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-9.gencloud-x86_64.ks",
+    "<leftCtrlOn>x<leftCtrlOff>",
   ]
 }
 
-local "gencloud_boot_command_9_aarch64" {
-  expression = [
-    "c<wait>",
-    "linux /images/pxeboot/vmlinuz",
-    " inst.stage2=hd:LABEL=AlmaLinux-9-${local.os_ver_minor_9}-aarch64-dvd ro",
-    " inst.text biosdevname=0 net.ifnames=0",
-    " inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-9.gencloud-aarch64.ks",
-    "<enter>",
-    "initrd /images/pxeboot/initrd.img<enter>",
-    "boot<enter><wait>",
+variable "gencloud_boot_command_9_aarch64" {
+  description = "Boot command for AlmaLinux OS 9 Generic Cloud AArch64"
+
+  type = list(string)
+
+  default = [
+    "e",
+    "<down><down>",
+    "<leftCtrlOn>e<leftCtrlOff>",
+    "<spacebar>",
+    "biosdevname=0",
+    "<spacebar>",
+    "net.ifnames=0",
+    "<spacebar>",
+    "inst.text",
+    "<spacebar>",
+    "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-9.gencloud-aarch64.ks",
+    "<leftCtrlOn>x<leftCtrlOff>",
   ]
 }
 
-local "gencloud_boot_command_9_ppc64le" {
-  expression = [
-    "c<wait>",
-    "linux /ppc/ppc64/vmlinuz",
-    " inst.stage2=hd:LABEL=AlmaLinux-9-${local.os_ver_minor_9}-ppc64le-dvd ro",
-    " inst.text biosdevname=0 net.ifnames=0",
-    " inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-9.gencloud-ppc64le.ks",
-    "<enter>",
-    "initrd /ppc/ppc64/initrd.img<enter>",
-    "boot<enter><wait>",
+variable "gencloud_boot_command_9_ppc64le" {
+  description = "Boot command for AlmaLinux OS 9 Generic Cloud ppc64le"
+
+  type = list(string)
+
+  default = [
+    "e",
+    "<down><down>",
+    "<leftCtrlOn>e<leftCtrlOff>",
+    "<spacebar>",
+    "biosdevname=0",
+    "<spacebar>",
+    "net.ifnames=0",
+    "<spacebar>",
+    "inst.text",
+    "<spacebar>",
+    "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-9.gencloud-ppc64le.ks",
+    "<leftCtrlOn>x<leftCtrlOff>",
   ]
 }
 
@@ -285,17 +306,24 @@ local "azure_boot_command_8_x86_64" {
   ]
 }
 
-local "azure_boot_command_9_x86_64" {
-  expression = [
-    "c<wait>",
-    "linuxefi /images/pxeboot/vmlinuz",
-    " inst.stage2=hd:LABEL=AlmaLinux-9-${local.os_ver_minor_9}-x86_64-dvd ro",
-    " inst.text biosdevname=0 net.ifnames=0",
-    " inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-9.azure-x86_64.ks",
-    "<enter>",
-    "initrdefi /images/pxeboot/initrd.img",
-    "<enter>",
-    "boot<enter><wait>",
+variable "azure_boot_command_9_x86_64" {
+  description = "Boot command for AlmaLinux OS 9 Azure x86_64"
+
+  type = list(string)
+
+  default = [
+    "e",
+    "<down><down>",
+    "<leftCtrlOn>e<leftCtrlOff>",
+    "<spacebar>",
+    "biosdevname=0",
+    "<spacebar>",
+    "net.ifnames=0",
+    "<spacebar>",
+    "inst.text",
+    "<spacebar>",
+    "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-9.azure-x86_64.ks",
+    "<leftCtrlOn>x<leftCtrlOff>",
   ]
 }
 
@@ -470,18 +498,24 @@ local "vagrant_boot_command_8_x86_64" {
   ]
 }
 
-local "vagrant_boot_command_9_x86_64" {
-  expression = [
-    "c",
-    "<wait>",
-    "linuxefi /images/pxeboot/vmlinuz",
-    " inst.stage2=hd:LABEL=AlmaLinux-9-${local.os_ver_minor_9}-x86_64-dvd ro",
-    " inst.text biosdevname=0 net.ifnames=0",
-    " inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-9.vagrant-x86_64.ks",
-    "<enter>",
-    "initrdefi /images/pxeboot/initrd.img",
-    "<enter>",
-    "boot<enter><wait>",
+variable "vagrant_boot_command_9_x86_64" {
+  description = "Boot command for AlmaLinux OS 9 Vagrant x86_64"
+
+  type = list(string)
+
+  default = [
+    "e",
+    "<down><down>",
+    "<leftCtrlOn>e<leftCtrlOff>",
+    "<spacebar>",
+    "biosdevname=0",
+    "<spacebar>",
+    "net.ifnames=0",
+    "<spacebar>",
+    "inst.text",
+    "<spacebar>",
+    "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-9.vagrant-x86_64.ks",
+    "<leftCtrlOn>x<leftCtrlOff>",
   ]
 }
 
@@ -497,13 +531,21 @@ variable "vagrant_boot_command_9_x86_64_bios" {
 }
 
 variable "vagrant_boot_command_9_aarch64" {
-  description = "Boot command for AArch64"
+  description = "Boot command for AlmaLinux OS 9 Vagrant AArch64"
 
   type = list(string)
   default = [
     "e",
-    "<down><down><end><bs><bs><bs><bs><bs>",
-    "inst.text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-9.vagrant-aarch64.ks",
+    "<down><down>",
+    "<leftCtrlOn>e<leftCtrlOff>",
+    "<spacebar>",
+    "biosdevname=0",
+    "<spacebar>",
+    "net.ifnames=0",
+    "<spacebar>",
+    "inst.text",
+    "<spacebar>",
+    "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-9.vagrant-aarch64.ks",
     "<leftCtrlOn>x<leftCtrlOff>",
   ]
 }


### PR DESCRIPTION
Instead of entering the command-line of GRUB2 by pressing c and rewriting a boot entry and inject the kickstart config, Editing the default GRUB2 boot entry
(e.g. "Test this media & Install AlmaLinux X.Y") provides some benefits:
- More safety with checking media for against any corruption before starting the Anaconda installer.
- Since there is a different boot entry for each architecture (e.g. x86_64, AArch64 and ppc64le) and option of the inst.stage2 should have the full version of the AlmaLinux OS
(e.g. "inst.stage2=hd:LABEL=AlmaLinux-9-5-x86_64-dvd"). We introduced a os_ver_minor_9 Packer local which is derived from the os_ver_9 Packer variable.
This new editing approach eliminates all these differences that should be cared of and provides a generic boot command to be used among the all image types and their architectures.
- Cleaner and Simpler: Which increases the maintainability across the major versions of AlmaLinux OS. In this case AlmaLinux OS 10 images will benefit from this approach using the same Packer boot command.