### PR TITLE
chore(cleanup_vm): moving the removal of persistent net rules

### DIFF
--- a/ansible/roles/cleanup_vm/tasks/main.yml
+++ b/ansible/roles/cleanup_vm/tasks/main.yml
@@ -1,6 +1,23 @@
 ---
-- name: Remove old kernels
-  shell: dnf remove -y $(dnf repoquery --installonly --latest-limit=-1 -q)
+- name: Remove older versions kernel and other packages
+  ansible.builtin.command: dnf -y remove --oldinstallonly
+  register: removeoldoutput
+  changed_when: removeoldoutput.rc == 0
+  ignore_errors: yes
+
+- name: Find persistent net rules
+  ansible.builtin.find:
+    paths: /etc/udev/rules.d
+    patterns: "70*"
+  register: persistnet_rules
+
+- name: Delete found persistent net rules
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ persistnet_rules.files }}"
+  loop_control:
+    label: "{{ item.path }}"
 
 - name: Delete DNF cache
   command: dnf clean all


### PR DESCRIPTION
- This couple of Ansible tasks make sure there is not persistent net rules left behind on /etc/udev/rules.d (e.g. 70-persistent-net.rules). Since nature of this operation is cleaning up the system for the image creation. It is better to move this operation from the gencloud_guest Ansible role to the cleanup_vm.

- Use the --oldinstallonly command-line argument of dnf remove command to remove old kernel and packages. Which specifically serves to this purpose.