### PR TITLE
feat: switch locale from C.UTF-8 to en_US.UTF-8

### DIFF
--- a/http/almalinux-8.gencloud-s390x.ks
+++ b/http/almalinux-8.gencloud-s390x.ks
@@ -14,7 +14,7 @@ skipx
 eula --agreed
 firstboot --disabled
 
-lang C.UTF-8
+lang en_US.UTF-8
 keyboard us
 timezone UTC --utc
 

--- a/http/almalinux-9.gencloud-aarch64.ks
+++ b/http/almalinux-9.gencloud-aarch64.ks
@@ -2,7 +2,7 @@
 
 url --url https://repo.almalinux.org/almalinux/9/BaseOS/aarch64/os
 text
-lang C.UTF-8
+lang en_US.UTF-8
 keyboard us
 timezone UTC --utc
 selinux --enforcing

--- a/http/almalinux-9.gencloud-ppc64le.ks
+++ b/http/almalinux-9.gencloud-ppc64le.ks
@@ -2,7 +2,7 @@
 
 url --url https://repo.almalinux.org/almalinux/9/BaseOS/ppc64le/os
 text
-lang C.UTF-8
+lang en_US.UTF-8
 keyboard us
 timezone UTC --utc
 selinux --enforcing

--- a/http/almalinux-9.gencloud-s390x.ks
+++ b/http/almalinux-9.gencloud-s390x.ks
@@ -11,7 +11,7 @@ skipx
 eula --agreed
 firstboot --disabled
 
-lang C.UTF-8
+lang en_US.UTF-8
 keyboard us
 timezone UTC --utc
 

--- a/http/almalinux-9.gencloud-x86_64.ks
+++ b/http/almalinux-9.gencloud-x86_64.ks
@@ -2,7 +2,7 @@
 
 url --url https://repo.almalinux.org/almalinux/9/BaseOS/x86_64/os
 text
-lang C.UTF-8
+lang en_US.UTF-8
 keyboard us
 timezone UTC --utc
 selinux --enforcing

--- a/http/almalinux-9.vagrant-aarch64.ks
+++ b/http/almalinux-9.vagrant-aarch64.ks
@@ -2,7 +2,7 @@
 
 url --url https://repo.almalinux.org/almalinux/9/BaseOS/aarch64/os
 text
-lang C.UTF-8
+lang en_US.UTF-8
 keyboard us
 timezone UTC --utc
 selinux --enforcing

--- a/http/almalinux-9.vagrant-x86_64-bios.ks
+++ b/http/almalinux-9.vagrant-x86_64-bios.ks
@@ -2,7 +2,7 @@
 
 url --url https://repo.almalinux.org/almalinux/9/BaseOS/x86_64/os
 text
-lang C.UTF-8
+lang en_US.UTF-8
 keyboard us
 timezone UTC --utc
 selinux --enforcing

--- a/http/almalinux-9.vagrant-x86_64.ks
+++ b/http/almalinux-9.vagrant-x86_64.ks
@@ -2,7 +2,7 @@
 
 url --url https://repo.almalinux.org/almalinux/9/BaseOS/x86_64/os
 text
-lang C.UTF-8
+lang en_US.UTF-8
 keyboard us
 timezone UTC --utc
 selinux --enforcing


### PR DESCRIPTION
When we were working on the implementation of
the initial AlmaLinux OS 9 cloud images, the C.UTF-8 was the only locale available because the exclusion of English locales packages (-langpacks-*) is used on the kickstart configurations. The reason behind this decision to improve the compatibility with the RHEL cloud images.

It also worth to mention that the exclusion of the English locales also makes the images smaller as a file size from the outside and more space on the root partition from the inside.

But not everything is optimized to work with the single C.UTF-8 locale. After observing some warnings due the unavailability of the en_US.UTF-8 locale on the logs of the applications over here and there. I believe it is better to have the en_US.UTF-8 other English locales installed. Since we don't replacing the C.UTF-8 but adding the en_US.UTF-8 locale. The users are able to set the right locale for their workloads. Thanks to the recent overhauling the installed package selection, the 9.5 images size are smaller yet have the English locales installed.