### PR TITLE
feat(azure): add aarch64 image sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,12 @@ See: [How to build UEFI and Secure Boot supported Images](https://github.com/Alm
 ```sh
 packer build -only=qemu.almalinux-8-azure-x86_64 .
 ```
+
+`AArch64`:
+
+```sh
+packer build -only=qemu.almalinux-8-azure-aarch64 .
+```
 #### AlmaLinux OS 9
 
 `x86_64` Unified Boot (BIOS and UEFI):
@@ -194,7 +200,17 @@ See: [How to build UEFI and Secure Boot supported Images](https://github.com/Alm
 packer build -only=qemu.almalinux-9-azure-x86_64 .
 ```
 
+`AArch64`:
 
+```sh
+packer build -only=qemu.almalinux-9-azure-aarch64 .
+```
+
+`AArch64` with with 64k page size kernel:
+
+```sh
+packer build -only=qemu.almalinux_9_azure_aarch64_64k .
+```
 ### Amazon Machine Images (AMI)
 
 #### Requirements

--- a/almalinux-8-azure.pkr.hcl
+++ b/almalinux-8-azure.pkr.hcl
@@ -31,8 +31,44 @@ source "qemu" "almalinux-8-azure-x86_64" {
   efi_drop_efivars   = true
 }
 
+source "qemu" "almalinux-8-azure-aarch64" {
+  iso_url            = local.iso_url_8_aarch64
+  iso_checksum       = local.iso_checksum_8_aarch64
+  http_directory     = var.http_directory
+  shutdown_command   = var.root_shutdown_command
+  ssh_username       = var.gencloud_ssh_username
+  ssh_password       = var.gencloud_ssh_password
+  ssh_timeout        = var.ssh_timeout
+  boot_command       = local.azure_boot_command_8_aarch64
+  boot_wait          = var.boot_wait
+  accelerator        = "kvm"
+  firmware           = var.aavmf_code
+  use_pflash         = false
+  disk_interface     = "virtio-scsi"
+  disk_size          = var.azure_disk_size
+  disk_cache         = "unsafe"
+  disk_discard       = "unmap"
+  disk_detect_zeroes = "unmap"
+  format             = "raw"
+  headless           = var.headless
+  machine_type       = "virt,gic-version=max"
+  memory             = var.memory_aarch64
+  net_device         = "virtio-net"
+  qemu_binary        = var.qemu_binary
+  vm_name            = "AlmaLinux-8-Azure-${var.os_ver_8}-${formatdate("YYYYMMDD", timestamp())}.aarch64.raw"
+  cpu_model          = "host"
+  cpus               = var.cpus
+  qemuargs = [
+    ["-boot", "strict=on"],
+    ["-monitor", "none"]
+  ]
+}
+
 build {
-  sources = ["source.qemu.almalinux-8-azure-x86_64"]
+  sources = [
+    "source.qemu.almalinux-8-azure-x86_64",
+    "source.qemu.almalinux-8-azure-aarch64",
+  ]
 
   provisioner "ansible" {
     galaxy_file          = "./ansible/requirements.yml"
@@ -49,5 +85,20 @@ build {
       "--extra-vars",
       "is_unified_boot=true",
     ]
+    only = ["qemu.almalinux-8-azure-x86_64"]
+  }
+
+  provisioner "ansible" {
+    galaxy_file          = "./ansible/requirements.yml"
+    galaxy_force_install = true
+    collections_path     = "./ansible/collections"
+    roles_path           = "./ansible/roles"
+    playbook_file        = "./ansible/azure.yml"
+    ansible_env_vars = [
+      "ANSIBLE_PIPELINING=True",
+      "ANSIBLE_REMOTE_TEMP=/tmp",
+      "ANSIBLE_SCP_EXTRA_ARGS=-O"
+    ]
+    only = ["qemu.almalinux-8-azure-aarch64"]
   }
 }

--- a/almalinux-9-azure.pkr.hcl
+++ b/almalinux-9-azure.pkr.hcl
@@ -31,8 +31,78 @@ source "qemu" "almalinux-9-azure-x86_64" {
   efi_drop_efivars   = true
 }
 
+source "qemu" "almalinux-9-azure-aarch64" {
+  iso_url            = local.iso_url_9_aarch64
+  iso_checksum       = local.iso_checksum_9_aarch64
+  http_directory     = var.http_directory
+  shutdown_command   = var.root_shutdown_command
+  ssh_username       = var.gencloud_ssh_username
+  ssh_password       = var.gencloud_ssh_password
+  ssh_timeout        = var.ssh_timeout
+  boot_command       = var.azure_boot_command_9_aarch64
+  boot_wait          = var.boot_wait
+  accelerator        = "kvm"
+  firmware           = var.aavmf_code
+  use_pflash         = false
+  disk_interface     = "virtio-scsi"
+  disk_size          = var.azure_disk_size
+  disk_cache         = "unsafe"
+  disk_discard       = "unmap"
+  disk_detect_zeroes = "unmap"
+  format             = "raw"
+  headless           = var.headless
+  machine_type       = "virt,gic-version=max"
+  memory             = var.memory_aarch64
+  net_device         = "virtio-net"
+  qemu_binary        = var.qemu_binary
+  vm_name            = "AlmaLinux-9-Azure-${var.os_ver_9}-${formatdate("YYYYMMDD", timestamp())}0.aarch64.raw"
+  cpu_model          = "host"
+  cpus               = var.cpus
+  qemuargs = [
+    ["-boot", "strict=on"],
+    ["-monitor", "none"]
+  ]
+}
+
+source "qemu" "almalinux_9_azure_aarch64_64k" {
+  iso_url            = local.iso_url_9_aarch64
+  iso_checksum       = local.iso_checksum_9_aarch64
+  http_directory     = var.http_directory
+  shutdown_command   = var.root_shutdown_command
+  ssh_username       = var.gencloud_ssh_username
+  ssh_password       = var.gencloud_ssh_password
+  ssh_timeout        = var.ssh_timeout
+  boot_command       = var.azure_boot_command_9_64k_aarch64
+  boot_wait          = var.boot_wait
+  accelerator        = "kvm"
+  firmware           = var.aavmf_code
+  use_pflash         = false
+  disk_interface     = "virtio-scsi"
+  disk_size          = var.azure_disk_size
+  disk_cache         = "unsafe"
+  disk_discard       = "unmap"
+  disk_detect_zeroes = "unmap"
+  format             = "raw"
+  headless           = var.headless
+  machine_type       = "virt,gic-version=max"
+  memory             = var.memory_aarch64
+  net_device         = "virtio-net"
+  qemu_binary        = var.qemu_binary
+  vm_name            = "AlmaLinux-Azure-${var.os_ver_9}-${formatdate("YYYYMMDD", timestamp())}0-64k.aarch64.raw"
+  cpu_model          = "host"
+  cpus               = var.cpus
+  qemuargs = [
+    ["-boot", "strict=on"],
+    ["-monitor", "none"]
+  ]
+}
+
 build {
-  sources = ["source.qemu.almalinux-9-azure-x86_64"]
+  sources = [
+    "source.qemu.almalinux-9-azure-x86_64",
+    "source.qemu.almalinux-9-azure-aarch64",
+    "source.qemu.almalinux_9_azure_aarch64_64k",
+  ]
 
   provisioner "ansible" {
     galaxy_file          = "./ansible/requirements.yml"

--- a/http/almalinux-8.azure-aarch64.ks
+++ b/http/almalinux-8.azure-aarch64.ks
@@ -1,0 +1,43 @@
+# AlmaLinux OS 8 kickstart file for Azure VM images on AArch64
+
+url --url https://repo.almalinux.org/almalinux/8/BaseOS/aarch64/kickstart/
+repo --name=BaseOS --baseurl=https://repo.almalinux.org/almalinux/8/BaseOS/aarch64/os/
+repo --name=AppStream --baseurl=https://repo.almalinux.org/almalinux/8/AppStream/aarch64/os/
+
+text
+skipx
+eula --agreed
+firstboot --disabled
+lang en_US.UTF-8
+keyboard us
+timezone UTC --isUtc
+network --bootproto=dhcp
+firewall --disabled
+services --disabled="kdump" --enabled="chronyd,rsyslog,sshd"
+selinux --enforcing
+
+bootloader --timeout=0 --location=mbr --append="loglevel=3 console=tty1 console=ttyAMA0 earlycon=pl011,0xeffec000 initcall_blacklist=arm_pmu_acpi_init rootdelay=300 no_timer_check net.ifnames=0"
+
+zerombr
+clearpart --all --initlabel
+part /boot/efi --fstype=efi --size=200
+part /boot --fstype=xfs --size=1024
+part / --fstype=xfs --grow
+
+rootpw --plaintext almalinux
+reboot --eject
+
+%packages
+@core
+-biosdevname
+-open-vm-tools
+-plymouth
+-dnf-plugin-spacewalk
+-rhn*
+-iprutils
+-iwl*-firmware
+%end
+
+# disable kdump service
+%addon com_redhat_kdump --disable
+%end

--- a/http/almalinux-9.azure-64k-aarch64.ks
+++ b/http/almalinux-9.azure-64k-aarch64.ks
@@ -1,0 +1,45 @@
+# AlmaLinux OS 9 kickstart file for Azure VM images with 64k page size kernel on AArch64
+
+url --url https://repo.almalinux.org/almalinux/9/BaseOS/aarch64/os
+text
+lang en_US.UTF-8
+keyboard us
+timezone UTC --utc
+selinux --enforcing
+firewall --disabled
+services --enabled=sshd
+
+bootloader --timeout=0 --location=mbr --append="loglevel=3 console=tty1 console=ttyAMA0 earlycon=pl011,0xeffec000 initcall_blacklist=arm_pmu_acpi_init rootdelay=300 no_timer_check net.ifnames=0"
+
+zerombr
+clearpart --all --initlabel
+part /boot/efi --fstype=efi --size=200
+part /boot --fstype=xfs --size=1024
+part / --fstype=xfs --grow
+
+rootpw --plaintext almalinux
+reboot --eject
+
+%packages --exclude-weakdeps --inst-langs=en
+kernel-64k
+dracut-config-generic
+tar
+-kmod-kvdo
+-vdo
+-kernel
+-*firmware
+-dracut-config-rescue
+-firewalld
+-qemu-guest-agent
+%end
+
+# disable kdump service
+%addon com_redhat_kdump --disable
+%end
+
+%post --erroronfail
+
+# permit root login via SSH with password authetication
+echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/01-permitrootlogin.conf
+
+%end

--- a/http/almalinux-9.azure-aarch64.ks
+++ b/http/almalinux-9.azure-aarch64.ks
@@ -1,0 +1,41 @@
+# AlmaLinux OS 9 kickstart file for Azure VM images on AArch64
+
+url --url https://repo.almalinux.org/almalinux/9/BaseOS/aarch64/os
+text
+lang en_US.UTF-8
+keyboard us
+timezone UTC --utc
+selinux --enforcing
+firewall --disabled
+services --enabled=sshd
+
+bootloader --timeout=0 --location=mbr --append="loglevel=3 console=tty1 console=ttyAMA0 earlycon=pl011,0xeffec000 initcall_blacklist=arm_pmu_acpi_init rootdelay=300 no_timer_check net.ifnames=0"
+
+zerombr
+clearpart --all --initlabel
+part /boot/efi --fstype=efi --size=200
+part /boot --fstype=xfs --size=1024
+part / --fstype=xfs --grow
+
+rootpw --plaintext almalinux
+reboot --eject
+
+%packages --exclude-weakdeps --inst-langs=en
+dracut-config-generic
+tar
+-*firmware
+-dracut-config-rescue
+-firewalld
+-qemu-guest-agent
+%end
+
+# disable kdump service
+%addon com_redhat_kdump --disable
+%end
+
+%post --erroronfail
+
+# permit root login via SSH with password authetication
+echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/01-permitrootlogin.conf
+
+%end

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -306,6 +306,20 @@ local "azure_boot_command_8_x86_64" {
   ]
 }
 
+local "azure_boot_command_8_aarch64" {
+  expression = [
+    "c<wait>",
+    "linux /images/pxeboot/vmlinuz",
+    " inst.stage2=hd:LABEL=AlmaLinux-8-${local.os_ver_minor_8}-aarch64-dvd ro",
+    " inst.text biosdevname=0 net.ifnames=0",
+    " inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-8.azure-aarch64.ks",
+    "<enter>",
+    "initrd /images/pxeboot/initrd.img",
+    "<enter>",
+    "boot<enter><wait>"
+  ]
+}
+
 variable "azure_boot_command_9_x86_64" {
   description = "Boot command for AlmaLinux OS 9 Azure x86_64"
 
@@ -327,6 +341,47 @@ variable "azure_boot_command_9_x86_64" {
   ]
 }
 
+variable "azure_boot_command_9_aarch64" {
+  description = "Boot command for AlmaLinux OS 9 Azure AArch64"
+
+  type = list(string)
+
+  default = [
+    "e",
+    "<down><down>",
+    "<leftCtrlOn>e<leftCtrlOff>",
+    "<spacebar>",
+    "biosdevname=0",
+    "<spacebar>",
+    "net.ifnames=0",
+    "<spacebar>",
+    "inst.text",
+    "<spacebar>",
+    "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-9.azure-aarch64.ks",
+    "<leftCtrlOn>x<leftCtrlOff>",
+  ]
+}
+
+variable "azure_boot_command_9_64k_aarch64" {
+  description = "Boot command for AlmaLinux OS 9 Azure with 64k page size kernel AArch64"
+
+  type = list(string)
+
+  default = [
+    "e",
+    "<down><down>",
+    "<leftCtrlOn>e<leftCtrlOff>",
+    "<spacebar>",
+    "biosdevname=0",
+    "<spacebar>",
+    "net.ifnames=0",
+    "<spacebar>",
+    "inst.text",
+    "<spacebar>",
+    "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-9.azure-64k-aarch64.ks",
+    "<leftCtrlOn>x<leftCtrlOff>",
+  ]
+}
 # AWS
 
 variable "aws_profile" {


### PR DESCRIPTION
Add sources of AlmaLinux OS 8 and 9 AArch64 Azure VM images below:
- AlmaLinux OS 8 AArch64.
- AlmaLinux OS 9 AArch64.
- AlmaLinux OS 9 AArch64 with 64k page size kernel.

resolves #192