### PR TITLE
feat: add support for build number version identifier

### DIFF
--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -22,6 +22,13 @@ variable "os_ver_9" {
   }
 }
 
+variable "build_number" {
+  description = "Build number identifier of an image version"
+
+  type    = number
+  default = 0
+}
+
 locals {
   os_ver_minor_8 = split(".", var.os_ver_8)[1]
 }


### PR DESCRIPTION
Using a build number identifier on the image versions brings some benefits on multiple stages:
- Development: Sometimes we want to build multiple images at same day and the naming of the image should be unique to be able to compare them or it is a necessity for the Amazon Machine Images, where Packer fails if it founds the name is already taken. Instead of manual and arbitrarily
renaming, setting a variable via three methods (Environment variable, command-line option and Packer auto loaded variable file) is much more convenient.
- Production: In future, it may possible to publish multiple images because of some quick bug fix on the same day. The incremental over the build number is needed here.