### PR TITLE
Use 'vagrant' user for ansible provisioner of images

### DIFF
--- a/almalinux-8-vagrant.pkr.hcl
+++ b/almalinux-8-vagrant.pkr.hcl
@@ -134,6 +134,7 @@ build {
   ]
 
   provisioner "ansible" {
+    user                 = "vagrant"
     galaxy_file          = "./ansible/requirements.yml"
     galaxy_force_install = true
     collections_path     = "./ansible/collections"

--- a/almalinux-9-vagrant.pkr.hcl
+++ b/almalinux-9-vagrant.pkr.hcl
@@ -201,6 +201,7 @@ build {
   ]
 
   provisioner "ansible" {
+    user                 = "vagrant"
     galaxy_file          = "./ansible/requirements.yml"
     galaxy_force_install = true
     collections_path     = "./ansible/collections"

--- a/almalinux_kitten_10_vagrant.pkr.hcl
+++ b/almalinux_kitten_10_vagrant.pkr.hcl
@@ -327,6 +327,7 @@ build {
   }
 
   provisioner "ansible" {
+    user                 = "vagrant"
     galaxy_file          = "./ansible/requirements.yml"
     galaxy_force_install = true
     collections_path     = "./ansible/collections"


### PR DESCRIPTION
- virtualbox-iso.almalinux-8 and virtualbox-iso.almalinux-9
- *.almalinux_kitten_10_vagrant_libvirt_x86_64 and *.almalinux_kitten_10_vagrant_libvirt_x86_64_v2
fixes #218 