### PR TITLE
fix(azure): increase io_timeout of nvme

### DIFF
--- a/http/almalinux-8.azure-aarch64.ks
+++ b/http/almalinux-8.azure-aarch64.ks
@@ -16,7 +16,7 @@ firewall --disabled
 services --disabled="kdump" --enabled="chronyd,rsyslog,sshd"
 selinux --enforcing
 
-bootloader --timeout=0 --location=mbr --append="loglevel=3 console=tty1 console=ttyAMA0 earlycon=pl011,0xeffec000 initcall_blacklist=arm_pmu_acpi_init rootdelay=300 no_timer_check net.ifnames=0"
+bootloader --timeout=0 --location=mbr --append="loglevel=3 console=tty1 console=ttyAMA0 earlycon=pl011,0xeffec000 initcall_blacklist=arm_pmu_acpi_init rootdelay=300 no_timer_check net.ifnames=0 nvme_core.io_timeout=240"
 
 zerombr
 clearpart --all --initlabel

--- a/http/almalinux-8.azure-x86_64.ks
+++ b/http/almalinux-8.azure-x86_64.ks
@@ -16,7 +16,7 @@ firewall --disabled
 services --disabled="kdump" --enabled="chronyd,rsyslog,sshd"
 selinux --enforcing
 
-bootloader --timeout=0 --location=mbr --append="loglevel=3 console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300 no_timer_check net.ifnames=0"
+bootloader --timeout=0 --location=mbr --append="loglevel=3 console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300 no_timer_check net.ifnames=0 nvme_core.io_timeout=240"
 
 %pre --erroronfail
 

--- a/http/almalinux-9.azure-64k-aarch64.ks
+++ b/http/almalinux-9.azure-64k-aarch64.ks
@@ -9,7 +9,7 @@ selinux --enforcing
 firewall --disabled
 services --enabled=sshd
 
-bootloader --timeout=0 --location=mbr --append="loglevel=3 console=tty1 console=ttyAMA0 earlycon=pl011,0xeffec000 initcall_blacklist=arm_pmu_acpi_init rootdelay=300 no_timer_check net.ifnames=0"
+bootloader --timeout=0 --location=mbr --append="loglevel=3 console=tty1 console=ttyAMA0 earlycon=pl011,0xeffec000 initcall_blacklist=arm_pmu_acpi_init rootdelay=300 no_timer_check net.ifnames=0 nvme_core.io_timeout=240"
 
 zerombr
 clearpart --all --initlabel

--- a/http/almalinux-9.azure-aarch64.ks
+++ b/http/almalinux-9.azure-aarch64.ks
@@ -9,7 +9,7 @@ selinux --enforcing
 firewall --disabled
 services --enabled=sshd
 
-bootloader --timeout=0 --location=mbr --append="loglevel=3 console=tty1 console=ttyAMA0 earlycon=pl011,0xeffec000 initcall_blacklist=arm_pmu_acpi_init rootdelay=300 no_timer_check net.ifnames=0"
+bootloader --timeout=0 --location=mbr --append="loglevel=3 console=tty1 console=ttyAMA0 earlycon=pl011,0xeffec000 initcall_blacklist=arm_pmu_acpi_init rootdelay=300 no_timer_check net.ifnames=0 nvme_core.io_timeout=240"
 
 zerombr
 clearpart --all --initlabel

--- a/http/almalinux-9.azure-x86_64.ks
+++ b/http/almalinux-9.azure-x86_64.ks
@@ -9,7 +9,7 @@ selinux --enforcing
 firewall --disabled
 services --enabled=sshd
 
-bootloader --timeout=0 --location=mbr --append="loglevel=3 console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300 no_timer_check net.ifnames=0"
+bootloader --timeout=0 --location=mbr --append="loglevel=3 console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300 no_timer_check net.ifnames=0 nvme_core.io_timeout=240"
 
 %pre --erroronfail
 parted -s -a optimal /dev/sda -- mklabel gpt

--- a/http/almalinux-kitten-10.azure-64k-aarch64.ks
+++ b/http/almalinux-kitten-10.azure-64k-aarch64.ks
@@ -9,7 +9,7 @@ selinux --enforcing
 firewall --disabled
 services --enabled=sshd
 
-bootloader --timeout=0 --location=mbr --append="loglevel=3 console=tty1 console=ttyAMA0 earlycon=pl011,0xeffec000 initcall_blacklist=arm_pmu_acpi_init rootdelay=300 no_timer_check net.ifnames=0"
+bootloader --timeout=0 --location=mbr --append="loglevel=3 console=tty1 console=ttyAMA0 earlycon=pl011,0xeffec000 initcall_blacklist=arm_pmu_acpi_init rootdelay=300 no_timer_check net.ifnames=0 nvme_core.io_timeout=240"
 
 zerombr
 clearpart --all --initlabel

--- a/http/almalinux-kitten-10.azure-aarch64.ks
+++ b/http/almalinux-kitten-10.azure-aarch64.ks
@@ -9,7 +9,7 @@ selinux --enforcing
 firewall --disabled
 services --enabled=sshd
 
-bootloader --timeout=0 --location=mbr --append="loglevel=3 console=tty1 console=ttyAMA0 earlycon=pl011,0xeffec000 initcall_blacklist=arm_pmu_acpi_init rootdelay=300 no_timer_check net.ifnames=0"
+bootloader --timeout=0 --location=mbr --append="loglevel=3 console=tty1 console=ttyAMA0 earlycon=pl011,0xeffec000 initcall_blacklist=arm_pmu_acpi_init rootdelay=300 no_timer_check net.ifnames=0 nvme_core.io_timeout=240"
 
 zerombr
 clearpart --all --initlabel

--- a/http/almalinux-kitten-10.azure-x86_64.ks
+++ b/http/almalinux-kitten-10.azure-x86_64.ks
@@ -9,7 +9,7 @@ selinux --enforcing
 firewall --disabled
 services --enabled=sshd
 
-bootloader --timeout=0 --location=mbr --append="loglevel=3 console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300 no_timer_check net.ifnames=0"
+bootloader --timeout=0 --location=mbr --append="loglevel=3 console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300 no_timer_check net.ifnames=0 nvme_core.io_timeout=240"
 
 %pre --erroronfail
 parted -s -a optimal /dev/sda -- mklabel gpt


### PR DESCRIPTION
Increase IO timeout of NVMe from 30 (default) to 240 as per recommendation from Azure.
fixes AlmaLinux/cloud-images#228