### PR TITLE
fix(azure): make NetworkManager to honor udev rules

### DIFF
--- a/ansible/roles/azure_guest/files/99-azure-unmanaged-devices.conf
+++ b/ansible/roles/azure_guest/files/99-azure-unmanaged-devices.conf
@@ -1,0 +1,4 @@
+# Ignore SR-IOV interface on Azure, since it's transparently bonded
+# to the synthetic interface
+[keyfile]
+unmanaged-devices=driver:mlx4_core;driver:mlx5_core

--- a/ansible/roles/azure_guest/tasks/main.yml
+++ b/ansible/roles/azure_guest/tasks/main.yml
@@ -112,6 +112,15 @@
     group: root
     mode: 0644
 
+- name: Configure NetworkManager for SRIOV interface
+  when: ansible_facts['distribution_major_version'] | int == 9
+  ansible.builtin.copy:
+    src: 99-azure-unmanaged-devices.conf
+    dest: /etc/NetworkManager/conf.d/99-azure-unmanaged-devices.conf
+    owner: root
+    group: root
+    mode: "0644"
+
 - name: Generate udev rules for PTP clock source
   when: ansible_facts['distribution_major_version'] == '8'
   copy:


### PR DESCRIPTION
On AlmaLinux OS 9, add a new NetworkManager configuration file to unmanage devices with the drivers listed below:
- mlx4_core
- mlx5_core

fixes #217 