### PR TITLE
fix(9): disable weak dependencies by default

### DIFF
--- a/ansible/roles/ami_9_aarch64/tasks/guest.yaml
+++ b/ansible/roles/ami_9_aarch64/tasks/guest.yaml
@@ -32,6 +32,7 @@
   ansible.builtin.dnf:
     installroot: /rootfs
     disable_gpg_check: true
+    install_weak_deps: false
     name:
       - cloud-init
       - cloud-utils-growpart

--- a/ansible/roles/ami_9_x86_64/tasks/guest.yaml
+++ b/ansible/roles/ami_9_x86_64/tasks/guest.yaml
@@ -32,6 +32,7 @@
   ansible.builtin.dnf:
     installroot: /rootfs
     disable_gpg_check: true
+    install_weak_deps: false
     name:
       - cloud-init
       - cloud-utils-growpart

--- a/ansible/roles/azure_guest/tasks/main.yml
+++ b/ansible/roles/azure_guest/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 - name: Install Hyper-V support and common utils
+  when: ansible_facts['distribution_major_version'] | int >= 9
   dnf:
+    install_weak_deps: false
     name:
       - hyperv-daemons
       - yum-utils

--- a/ansible/roles/gencloud_guest/tasks/main.yml
+++ b/ansible/roles/gencloud_guest/tasks/main.yml
@@ -25,18 +25,16 @@
 
 # Optimizations
 - name: Install additional packages
+  when: ansible_facts['distribution_major_version'] | int >= 9
   ansible.builtin.dnf:
+    install_weak_deps: false
     name:
       - qemu-guest-agent
       - nfs-utils
       - rsync
       - jq
       - tcpdump
-    state: present
-
-- name: Install TuneD
-  ansible.builtin.dnf:
-    name: tuned
+      - tuned
     state: present
 
 - name: Enable TuneD service

--- a/ansible/roles/hyperv_guest/tasks/main.yml
+++ b/ansible/roles/hyperv_guest/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 - name: Install Hyper-V dependencies
+  when: ansible_facts['distribution_major_version'] | int >= 9
   dnf:
+    install_weak_deps: false
     name:
       - cifs-utils
       - hyperv-daemons

--- a/ansible/roles/oci_guest/tasks/main.yaml
+++ b/ansible/roles/oci_guest/tasks/main.yaml
@@ -6,7 +6,9 @@
     replace: "\\1kernel"
 
 - name: Install additional packages
+  when: ansible_facts['distribution_major_version'] | int >= 9
   ansible.builtin.dnf:
+    install_weak_deps: false
     name:
       - qemu-guest-agent
       - nfs-utils
@@ -18,7 +20,9 @@
     state: present
 
 - name: Install iSCSI tools
+  when: ansible_facts['distribution_major_version'] | int >= 9
   ansible.builtin.dnf:
+    install_weak_deps: false
     name:
       - iscsi-initiator-utils
       - iscsi-initiator-utils-iscsiuio

--- a/ansible/roles/opennebula_guest/tasks/main.yml
+++ b/ansible/roles/opennebula_guest/tasks/main.yml
@@ -38,18 +38,16 @@
     state: latest
 
 - name: Install additional packages
+  when: ansible_facts['distribution_major_version'] | int >= 9
   ansible.builtin.dnf:
+    install_weak_deps: false
     name:
       - qemu-guest-agent
       - nfs-utils
       - rsync
       - jq
       - tcpdump
-    state: present
-
-- name: Install TuneD
-  ansible.builtin.dnf:
-    name: tuned
+      - tuned
     state: present
 
 - name: Enable TuneD service

--- a/ansible/roles/qemu_guest/tasks/main.yml
+++ b/ansible/roles/qemu_guest/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
-- name: Install qemu-guest-agent and rsync
+- name: Install qemu-guest-agent
+  when: ansible_facts['distribution_major_version'] | int >= 9
   dnf:
-    name:
-      - qemu-guest-agent
+    install_weak_deps: false
+    name: qemu-guest-agent
     state: latest

--- a/ansible/roles/vagrant_guest/tasks/main.yaml
+++ b/ansible/roles/vagrant_guest/tasks/main.yaml
@@ -9,7 +9,9 @@
     create: false
 
 - name: Install additional packages
+  when: ansible_facts['distribution_major_version'] | int >= 9
   ansible.builtin.dnf:
+    install_weak_deps: false
     name:
       - cifs-utils
       - jq

--- a/ansible/roles/vmware_guest/tasks/main.yml
+++ b/ansible/roles/vmware_guest/tasks/main.yml
@@ -1,5 +1,7 @@
 ---
 - name: Install open-vm-tools
+  when: ansible_facts['distribution_major_version'] | int >= 9
   dnf:
+    install_weak_deps: false
     name: open-vm-tools
     state: latest


### PR DESCRIPTION
Starting with AlmaLinux OS 9.6, installation of tuned packages also installs the python3-perf which itself installs the Perl base and other perl packages as weak dependencies.

Disabling of weak dependencies on AlmaLinux OS 9 and newer will help to prevent from such situations.