### PR TITLE
fix(10): iscsi support on bare metal instances

### DIFF
--- a/http/almalinux-10.oci-aarch64.ks
+++ b/http/almalinux-10.oci-aarch64.ks
@@ -9,7 +9,7 @@ selinux --enforcing
 firewall --disabled
 services --enabled=sshd
 
-bootloader --timeout=0 --location=mbr --append="console=ttyAMA0 console=ttyAMA0,115200n8 no_timer_check net.ifnames=0 netroot=iscsi:169.254.0.2:::1:iqn.2015-02.oracle.boot:uefi rd.iscsi.param=node.session.timeo.replacement_timeout=6000 libiscsi.debug_libiscsi_eh=1 nvme_core.shutdown_timeout=10"
+bootloader --timeout=0 --location=mbr --append="console=ttyAMA0 console=ttyAMA0,115200n8 no_timer_check net.ifnames=0 netroot=iscsi rd.iscsi.firmware=1 rd.iscsi.param=node.session.timeo.replacement_timeout=6000 libiscsi.debug_libiscsi_eh=1 nvme_core.shutdown_timeout=10"
 
 zerombr
 clearpart --all --initlabel
@@ -22,6 +22,7 @@ reboot --eject
 
 %packages --exclude-weakdeps --inst-langs=en
 dracut-config-generic
+dracut-network
 tar
 rsyslog-logrotate
 -*firmware

--- a/http/almalinux-10.oci-x86_64.ks
+++ b/http/almalinux-10.oci-x86_64.ks
@@ -9,7 +9,7 @@ selinux --enforcing
 firewall --disabled
 services --enabled=sshd
 
-bootloader --timeout=0 --location=mbr --append="console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 netroot=iscsi:169.254.0.2:::1:iqn.2015-02.oracle.boot:uefi rd.iscsi.param=node.session.timeo.replacement_timeout=6000 libiscsi.debug_libiscsi_eh=1 nvme_core.shutdown_timeout=10"
+bootloader --timeout=0 --location=mbr --append="console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 netroot=iscsi rd.iscsi.firmware=1 rd.iscsi.param=node.session.timeo.replacement_timeout=6000 libiscsi.debug_libiscsi_eh=1 nvme_core.shutdown_timeout=10"
 
 %pre --erroronfail
 parted -s -a optimal /dev/sda -- mklabel gpt
@@ -29,6 +29,7 @@ reboot --eject
 
 %packages --exclude-weakdeps --inst-langs=en
 dracut-config-generic
+dracut-network
 grub2-pc
 tar
 rsyslog-logrotate


### PR DESCRIPTION
The iSCSI protocol is used for boot volumes of bare metal type of instances. Those changes make the initramfs to correctly identify, configure the necessary filesystems to able to finish the boot process.

- Install dracut-network package to include iSCSI support into initramfs.
- Add rd.iscsi.firmware=1 dracut kernel command line option to read the iscsi parameter from the BIOS firmware.