### PR TITLE
fix(10-ami): fix package installation and naming

### DIFF
--- a/ansible/roles/ami_10_aarch64/tasks/guest.yaml
+++ b/ansible/roles/ami_10_aarch64/tasks/guest.yaml
@@ -28,37 +28,70 @@
     - "# Amazon Time Sync Service"
     - server 169.254.169.123 prefer iburst minpoll 4 maxpoll 4
 
-- name: Install additional software
-  ansible.builtin.dnf:
-    installroot: /rootfs
-    disable_gpg_check: true
-    name:
-      - cloud-init
-      - cloud-utils-growpart
-      - rsync
-      - tuned
-      - nvme-cli
-      - jq
-      - nfs-utils
-      - sos
-      - tcpdump
-    state: present
+# BUG: It uses the host's RPM repositories to install dependencies instead of the installroot's.
+# - name: Install additional software
+#   ansible.builtin.dnf:
+#     installroot: /rootfs
+#     disable_gpg_check: true
+#     name:
+#       - cloud-init
+#       - cloud-utils-growpart
+#       - rsync
+#       - tuned
+#       - nvme-cli
+#       - jq
+#       - nfs-utils
+#       - sos
+#       - tcpdump
+#     state: present
+
+- name: Install additional softwares
+  ansible.builtin.command:
+    cmd: >
+      dnf -y --installroot=/rootfs --nogpgcheck --setopt=install_weak_deps=False --setopt=cachedir=/var/cache/dnf install
+      cloud-init
+      cloud-utils-growpart
+      rsync
+      tuned
+      nvme-cli
+      jq
+      nfs-utils
+      sos
+      tcpdump
+  changed_when: true
+
+# BUG: It uses the host's RPM repositories to install dependencies instead of the installroot's.
+# - name: Install AWS Systems Manager Agent (SSM Agent)
+#   ansible.builtin.dnf:
+#     installroot: /rootfs
+#     disable_gpg_check: true
+#     name: https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_arm64/amazon-ssm-agent.rpm
+#     state: present
 
 - name: Install AWS Systems Manager Agent (SSM Agent)
-  ansible.builtin.dnf:
-    installroot: /rootfs
-    disable_gpg_check: true
-    name: https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_arm64/amazon-ssm-agent.rpm
-    state: present
+  ansible.builtin.command:
+    cmd: >
+      dnf -y --installroot=/rootfs --nogpgcheck --setopt=install_weak_deps=False --setopt=cachedir=/var/cache/dnf install
+      https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_arm64/amazon-ssm-agent.rpm
+  changed_when: true
+
+# BUG: It uses the host's RPM repositories to install dependencies instead of the installroot's.
+# - name: Install AWS EC2 Instance Connect
+#   ansible.builtin.dnf:
+#     installroot: /rootfs
+#     disable_gpg_check: true
+#     name:
+#       - https://amazon-ec2-instance-connect-us-west-2.s3.us-west-2.amazonaws.com/latest/linux_arm64/ec2-instance-connect.rpm
+#       - https://amazon-ec2-instance-connect-us-west-2.s3.us-west-2.amazonaws.com/latest/linux_amd64/ec2-instance-connect-selinux.noarch.rpm
+#     state: present
 
 - name: Install AWS EC2 Instance Connect
-  ansible.builtin.dnf:
-    installroot: /rootfs
-    disable_gpg_check: true
-    name:
-      - https://amazon-ec2-instance-connect-us-west-2.s3.us-west-2.amazonaws.com/latest/linux_arm64/ec2-instance-connect.rpm
-      - https://amazon-ec2-instance-connect-us-west-2.s3.us-west-2.amazonaws.com/latest/linux_amd64/ec2-instance-connect-selinux.noarch.rpm
-    state: present
+  ansible.builtin.command:
+    cmd: >
+      dnf -y --installroot=/rootfs --nogpgcheck --setopt=install_weak_deps=False --setopt=cachedir=/var/cache/dnf install
+      https://amazon-ec2-instance-connect-us-west-2.s3.us-west-2.amazonaws.com/latest/linux_arm64/ec2-instance-connect.rpm
+      https://amazon-ec2-instance-connect-us-west-2.s3.us-west-2.amazonaws.com/latest/linux_amd64/ec2-instance-connect-selinux.noarch.rpm
+  changed_when: true
 
 - name: Configure NetworkManager in cloud
   ansible.builtin.file:

--- a/ansible/roles/ami_10_aarch64/tasks/os.yaml
+++ b/ansible/roles/ami_10_aarch64/tasks/os.yaml
@@ -34,12 +34,19 @@
     cmd: rpm --root=/rootfs --nodeps -ivh https://repo.almalinux.org/almalinux/almalinux-repos-latest-10.aarch64.rpm
   changed_when: true
 
-- name: Update the system # noqa: package-latest
-  ansible.builtin.dnf:
-    installroot: /rootfs
-    disable_gpg_check: true
-    name: "*"
-    state: latest
+# BUG: It uses the host's RPM repositories to install dependencies instead of the installroot's.
+# - name: Update the system # noqa: package-latest
+#   ansible.builtin.dnf:
+#     installroot: /rootfs
+#     disable_gpg_check: true
+#     name: "*"
+#     state: latest
+
+- name: Update the system
+  ansible.builtin.command:
+    cmd: >
+      dnf -y --installroot=/rootfs --nogpgcheck --setopt=install_weak_deps=False --setopt=cachedir=/var/cache/dnf upgrade
+  changed_when: true
 
 - name: Creating fstab
   ansible.builtin.template:

--- a/ansible/roles/ami_10_aarch64/tasks/selinux.yaml
+++ b/ansible/roles/ami_10_aarch64/tasks/selinux.yaml
@@ -12,5 +12,9 @@
 
 - name: Install SELinux
   ansible.builtin.command:
-    cmd: dnf --installroot=/rootfs --nogpgcheck -y reinstall selinux-policy-targeted libselinux-utils policycoreutils
+    cmd: >
+      dnf -y --installroot=/rootfs --nogpgcheck --setopt=install_weak_deps=False --setopt=cachedir=/var/cache/dnf reinstall
+      selinux-policy-targeted
+      libselinux-utils
+      policycoreutils
   changed_when: true

--- a/ansible/roles/ami_10_x86_64/tasks/guest.yaml
+++ b/ansible/roles/ami_10_x86_64/tasks/guest.yaml
@@ -28,37 +28,70 @@
     - "# Amazon Time Sync Service"
     - server 169.254.169.123 prefer iburst minpoll 4 maxpoll 4
 
-- name: Install additional software
-  ansible.builtin.dnf:
-    installroot: /rootfs
-    disable_gpg_check: true
-    name:
-      - cloud-init
-      - cloud-utils-growpart
-      - rsync
-      - tuned
-      - nvme-cli
-      - jq
-      - nfs-utils
-      - sos
-      - tcpdump
-    state: present
+# BUG: It uses the host's RPM repositories to install dependencies instead of the installroot's.
+# - name: Install additional software
+#   ansible.builtin.dnf:
+#     installroot: /rootfs
+#     disable_gpg_check: true
+#     name:
+#       - cloud-init
+#       - cloud-utils-growpart
+#       - rsync
+#       - tuned
+#       - nvme-cli
+#       - jq
+#       - nfs-utils
+#       - sos
+#       - tcpdump
+#     state: present
+
+- name: Install additional softwares
+  ansible.builtin.command:
+    cmd: >
+      dnf -y --installroot=/rootfs --nogpgcheck --setopt=install_weak_deps=False --setopt=cachedir=/var/cache/dnf install
+      cloud-init
+      cloud-utils-growpart
+      rsync
+      tuned
+      nvme-cli
+      jq
+      nfs-utils
+      sos
+      tcpdump
+  changed_when: true
+
+# BUG: It uses the host's RPM repositories to install dependencies instead of the installroot's.
+# - name: Install AWS Systems Manager Agent (SSM Agent)
+#   ansible.builtin.dnf:
+#     installroot: /rootfs
+#     disable_gpg_check: true
+#     name: https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+#     state: present
 
 - name: Install AWS Systems Manager Agent (SSM Agent)
-  ansible.builtin.dnf:
-    installroot: /rootfs
-    disable_gpg_check: true
-    name: https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
-    state: present
+  ansible.builtin.command:
+    cmd: >
+      dnf -y --installroot=/rootfs --nogpgcheck --setopt=install_weak_deps=False --setopt=cachedir=/var/cache/dnf install
+      https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+  changed_when: true
+
+# BUG: It uses the host's RPM repositories to install dependencies instead of the installroot's.
+# - name: Install AWS EC2 Instance Connect
+#   ansible.builtin.dnf:
+#     installroot: /rootfs
+#     disable_gpg_check: true
+#     name:
+#       - https://amazon-ec2-instance-connect-us-west-2.s3.us-west-2.amazonaws.com/latest/linux_amd64/ec2-instance-connect.rpm
+#       - https://amazon-ec2-instance-connect-us-west-2.s3.us-west-2.amazonaws.com/latest/linux_amd64/ec2-instance-connect-selinux.noarch.rpm
+#     state: present
 
 - name: Install AWS EC2 Instance Connect
-  ansible.builtin.dnf:
-    installroot: /rootfs
-    disable_gpg_check: true
-    name:
-      - https://amazon-ec2-instance-connect-us-west-2.s3.us-west-2.amazonaws.com/latest/linux_amd64/ec2-instance-connect.rpm
-      - https://amazon-ec2-instance-connect-us-west-2.s3.us-west-2.amazonaws.com/latest/linux_amd64/ec2-instance-connect-selinux.noarch.rpm
-    state: present
+  ansible.builtin.command:
+    cmd: >
+      dnf -y --installroot=/rootfs --nogpgcheck --setopt=install_weak_deps=False --setopt=cachedir=/var/cache/dnf install
+      https://amazon-ec2-instance-connect-us-west-2.s3.us-west-2.amazonaws.com/latest/linux_amd64/ec2-instance-connect.rpm
+      https://amazon-ec2-instance-connect-us-west-2.s3.us-west-2.amazonaws.com/latest/linux_amd64/ec2-instance-connect-selinux.noarch.rpm
+  changed_when: true
 
 - name: Configure NetworkManager in cloud
   ansible.builtin.file:

--- a/ansible/roles/ami_10_x86_64/tasks/os.yaml
+++ b/ansible/roles/ami_10_x86_64/tasks/os.yaml
@@ -34,12 +34,19 @@
     cmd: rpm --root=/rootfs --nodeps -ivh https://repo.almalinux.org/almalinux/almalinux-repos-latest-10.x86_64.rpm
   changed_when: true
 
-- name: Update the system # noqa: package-latest
-  ansible.builtin.dnf:
-    installroot: /rootfs
-    disable_gpg_check: true
-    name: "*"
-    state: latest
+# BUG: It uses the host's RPM repositories to install dependencies instead of the installroot's.
+# - name: Update the system # noqa: package-latest
+#   ansible.builtin.dnf:
+#     installroot: /rootfs
+#     disable_gpg_check: true
+#     name: "*"
+#     state: latest
+
+- name: Update the system
+  ansible.builtin.command:
+    cmd: >
+      dnf -y --installroot=/rootfs --nogpgcheck --setopt=install_weak_deps=False --setopt=cachedir=/var/cache/dnf upgrade
+  changed_when: true
 
 - name: Creating fstab
   ansible.builtin.template:

--- a/ansible/roles/ami_10_x86_64/tasks/selinux.yaml
+++ b/ansible/roles/ami_10_x86_64/tasks/selinux.yaml
@@ -12,5 +12,9 @@
 
 - name: Install SELinux
   ansible.builtin.command:
-    cmd: dnf --installroot=/rootfs --nogpgcheck -y reinstall selinux-policy-targeted libselinux-utils policycoreutils
+    cmd: >
+      dnf -y --installroot=/rootfs --nogpgcheck --setopt=install_weak_deps=False --setopt=cachedir=/var/cache/dnf reinstall
+      selinux-policy-targeted
+      libselinux-utils
+      policycoreutils
   changed_when: true

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -865,23 +865,23 @@ local "aws_ami_version_kitten_10" {
 }
 # AlmaLinux OS 10
 local "aws_ami_name_x86_64_10" {
-  expression = "AlmaLinux OS 10.${formatdate("YYYYMMDD", timestamp())}.${var.build_number} x86_64"
+  expression = "AlmaLinux OS ${var.os_ver_10}.${formatdate("YYYYMMDD", timestamp())}.${var.build_number} x86_64"
 }
 
 local "aws_ami_name_aarch64_10" {
-  expression = "AlmaLinux OS 10.${formatdate("YYYYMMDD", timestamp())}.${var.build_number} aarch64"
+  expression = "AlmaLinux OS ${var.os_ver_10}.${formatdate("YYYYMMDD", timestamp())}.${var.build_number} aarch64"
 }
 
 local "aws_ami_description_x86_64_10" {
-  expression = "Official AlmaLinux OS 10 x86_64 Amazon Machine Image"
+  expression = "Official AlmaLinux OS ${var.os_ver_10} x86_64 Amazon Machine Image"
 }
 
 local "aws_ami_description_aarch64_10" {
-  expression = "Official AlmaLinux OS 10 aarch64 Amazon Machine Image"
+  expression = "Official AlmaLinux OS ${var.os_ver_10} aarch64 Amazon Machine Image"
 }
 
 local "aws_ami_version_10" {
-  expression = "10.${formatdate("YYYYMMDD", timestamp())}.${var.build_number}"
+  expression = "${var.os_ver_10}.${formatdate("YYYYMMDD", timestamp())}.${var.build_number}"
 }
 # AlmaLinux OS 8
 variable "aws_source_ami_8_x86_64" {
@@ -930,14 +930,14 @@ variable "aws_source_ami_10_x86_64" {
   description = "AlmaLinux OS 10 x86_64 AMI as source"
 
   type    = string
-  default = "ami-0bcea1e66829fec5b"
+  default = "ami-01d87dc7c538eb2b3"
 }
 
 variable "aws_source_ami_10_aarch64" {
   description = "AlmaLinux OS 10 AArch64 AMI as source"
 
   type    = string
-  default = "ami-0707e89f669cb9128"
+  default = "ami-0088cc5c1715837e1"
 }
 # Vagrant
 


### PR DESCRIPTION
ansible.builtin.dnf uses the host's RPM repositories to install dependencies instead of system on the installroot parameter. The source of this bug is might be the DNF Python API which is a requirement and used by of the ansible.builtin.dnf.

Which is results with:
- Error on different major versions e.g. Build AlmaLinux OS 10 AMI on AlmaLinux OS 9.
- Installation of wrong packages into the installroot. For instance, when build an AlmaLinux OS 10 on top of the AlmaLinux OS Kitten 10. It installs the AlmaLinux OS Kitten 10 versions of the packages instead of the AlmaLinux OS 10.

Using dnf itself is fixes these two cases.

- Fixed AMI naming by adding the full version of the AlmaLinux OS 10
- Fixed AMI Description and version to have full version identifier.