### PR TITLE
fix: disable weak dependencies

### DIFF
--- a/ansible/roles/azure_guest/tasks/main.yml
+++ b/ansible/roles/azure_guest/tasks/main.yml
@@ -1,8 +1,7 @@
 ---
 - name: Install Hyper-V support and common utils
-  when: ansible_facts['distribution_major_version'] | int >= 9
   dnf:
-    install_weak_deps: false
+    install_weak_deps: "{{ false if ansible_facts['distribution_major_version'] | int >= 9 else omit }}"
     name:
       - hyperv-daemons
       - yum-utils

--- a/ansible/roles/gencloud_guest/tasks/main.yml
+++ b/ansible/roles/gencloud_guest/tasks/main.yml
@@ -25,9 +25,8 @@
 
 # Optimizations
 - name: Install additional packages
-  when: ansible_facts['distribution_major_version'] | int >= 9
   ansible.builtin.dnf:
-    install_weak_deps: false
+    install_weak_deps: "{{ false if ansible_facts['distribution_major_version'] | int >= 9 else omit }}"
     name:
       - qemu-guest-agent
       - nfs-utils

--- a/ansible/roles/hyperv_guest/tasks/main.yml
+++ b/ansible/roles/hyperv_guest/tasks/main.yml
@@ -1,8 +1,7 @@
 ---
 - name: Install Hyper-V dependencies
-  when: ansible_facts['distribution_major_version'] | int >= 9
   dnf:
-    install_weak_deps: false
+    install_weak_deps: "{{ false if ansible_facts['distribution_major_version'] | int >= 9 else omit }}"
     name:
       - cifs-utils
       - hyperv-daemons

--- a/ansible/roles/oci_guest/tasks/main.yaml
+++ b/ansible/roles/oci_guest/tasks/main.yaml
@@ -6,9 +6,8 @@
     replace: "\\1kernel"
 
 - name: Install additional packages
-  when: ansible_facts['distribution_major_version'] | int >= 9
   ansible.builtin.dnf:
-    install_weak_deps: false
+    install_weak_deps: "{{ false if ansible_facts['distribution_major_version'] | int >= 9 else omit }}"
     name:
       - qemu-guest-agent
       - nfs-utils
@@ -20,9 +19,8 @@
     state: present
 
 - name: Install iSCSI tools
-  when: ansible_facts['distribution_major_version'] | int >= 9
   ansible.builtin.dnf:
-    install_weak_deps: false
+    install_weak_deps: "{{ false if ansible_facts['distribution_major_version'] | int >= 9 else omit }}"
     name:
       - iscsi-initiator-utils
       - iscsi-initiator-utils-iscsiuio

--- a/ansible/roles/opennebula_guest/tasks/main.yml
+++ b/ansible/roles/opennebula_guest/tasks/main.yml
@@ -38,9 +38,8 @@
     state: latest
 
 - name: Install additional packages
-  when: ansible_facts['distribution_major_version'] | int >= 9
   ansible.builtin.dnf:
-    install_weak_deps: false
+    install_weak_deps: "{{ false if ansible_facts['distribution_major_version'] | int >= 9 else omit }}"
     name:
       - qemu-guest-agent
       - nfs-utils

--- a/ansible/roles/qemu_guest/tasks/main.yml
+++ b/ansible/roles/qemu_guest/tasks/main.yml
@@ -1,7 +1,6 @@
 ---
 - name: Install qemu-guest-agent
-  when: ansible_facts['distribution_major_version'] | int >= 9
   dnf:
-    install_weak_deps: false
+    install_weak_deps: "{{ false if ansible_facts['distribution_major_version'] | int >= 9 else omit }}"
     name: qemu-guest-agent
     state: latest

--- a/ansible/roles/vagrant_guest/tasks/main.yaml
+++ b/ansible/roles/vagrant_guest/tasks/main.yaml
@@ -9,9 +9,8 @@
     create: false
 
 - name: Install additional packages
-  when: ansible_facts['distribution_major_version'] | int >= 9
   ansible.builtin.dnf:
-    install_weak_deps: false
+    install_weak_deps: "{{ false if ansible_facts['distribution_major_version'] | int >= 9 else omit }}"
     name:
       - cifs-utils
       - jq

--- a/ansible/roles/vmware_guest/tasks/main.yml
+++ b/ansible/roles/vmware_guest/tasks/main.yml
@@ -1,7 +1,6 @@
 ---
 - name: Install open-vm-tools
-  when: ansible_facts['distribution_major_version'] | int >= 9
   dnf:
-    install_weak_deps: false
+    install_weak_deps: "{{ false if ansible_facts['distribution_major_version'] | int >= 9 else omit }}"
     name: open-vm-tools
     state: latest


### PR DESCRIPTION
Current `when: ansible_facts['distribution_major_version'] | int >= 9` implementation disables the whole step for AlmaLinux 8 images where it applies.

Instead the `install_weak_deps: false` option should be set for 'ansible.builtin.dnf' module.