### PR TITLE
refactor(CI): Use RunsOn instead of "EC2 Github Action Builder" if github.repository_owner is AlmaLinux

### DIFF
--- a/.github/actions/shared-steps/action.yml
+++ b/.github/actions/shared-steps/action.yml
@@ -93,47 +93,51 @@ runs:
         image_type=${image_type//_/ }
         image_type=${image_type^}
 
-        # Release version
-        if [[ ${version_major} != *'kitten'* ]]; then
-          almalinux_release=https://repo.almalinux.org/almalinux/almalinux-release-latest-${version_major}.${{ env.alma_arch }}.rpm
+        # Release string and version
+        if [[ ${{ env.version_major }} != *'kitten'* ]]; then
+          almalinux_release=https://repo.almalinux.org/almalinux/almalinux-release-latest-${{ env.version_major }}.${{ env.alma_arch }}.rpm
           release=$(rpm -q --qf="%{VERSION}\n" ${almalinux_release} 2>/dev/null)
+          release_string="AlmaLinux release ${release}"
+          release_package="almalinux-release"
         else
           release=10
+          release_string="AlmaLinux Kitten release ${release}"
+          release_package="almalinux-kitten-release"
         fi
 
         # Packer source for image set in .pkr.hcl configs, e.g. almalinux-9-gencloud-x86_64, almalinux-9-azure-x86_64, ...
-        packer_source=almalinux-${version_major}-${{ inputs.type }}-${{ env.alma_arch }}
+        packer_source=almalinux-${{ env.version_major }}-${{ inputs.type }}-${{ env.alma_arch }}
 
         # Mask to locate output image file
-        output_mask=${packer_source}/AlmaLinux-${version_major}-*.${{ env.alma_arch }}.qcow2
+        output_mask=${packer_source}/AlmaLinux-${{ env.version_major }}-*.${{ env.alma_arch }}.qcow2
 
         # AWS S3 path to store images
-        aws_s3_path=images/${version_major}/${release}/${{ inputs.type }}/${{ env.TIME_STAMP }}
+        aws_s3_path=images/${{ env.version_major }}/${release}/${{ inputs.type }}/${{ env.TIME_STAMP }}
 
         # Overriding packer source, image mask and S3 path where necessary
-        case "${{ inputs.type }}${version_major}" in
+        case "${{ inputs.type }}${{ env.version_major }}" in
           azure8|azure9)
-            [[ ${{ inputs.variant }} == *"64k"* ]] && packer_source="almalinux_${version_major}_${{ inputs.type }}_64k_${{ env.alma_arch }}"
-            output_mask=output-${packer_source}/AlmaLinux-*${version_major}*.${{ env.alma_arch }}.raw
+            [[ ${{ inputs.variant }} == *"64k"* ]] && packer_source="almalinux_${{ env.version_major }}_${{ inputs.type }}_64k_${{ env.alma_arch }}"
+            output_mask=output-${packer_source}/AlmaLinux-*${{ env.version_major }}*.${{ env.alma_arch }}.raw
             packer_source=qemu.${packer_source}
             ;;
           azure*kitten*)
             packer_source=almalinux_kitten_10_${{ inputs.type }}_${{ env.alma_arch }}
-            [[ ${version_major} == *"v2"* ]] && packer_source="${packer_source}_v2"
+            [[ ${{ env.version_major }} == *"v2"* ]] && packer_source="${packer_source}_v2"
             [[ ${{ inputs.variant }} == *"64k"* ]] && packer_source="${packer_source}_64k"
             output_mask=output-${packer_source}/AlmaLinux-Kitten-*.${{ env.alma_arch }}*.raw
             aws_s3_path=images/kitten/10/${{ inputs.type }}/${{ env.TIME_STAMP }}
             packer_source=qemu.${packer_source}
             ;;
           azure10)
-            packer_source=almalinux_${version_major}_${{ inputs.type }}_${{ env.alma_arch }}
-            [[ ${version_major} == *"v2"* ]] && packer_source="${packer_source}_v2"
-            [[ ${{ inputs.variant }} == *"64k"* ]] && packer_source="almalinux_${version_major}_${{ inputs.type }}_64k_${{ env.alma_arch }}"
+            packer_source=almalinux_${{ env.version_major }}_${{ inputs.type }}_${{ env.alma_arch }}
+            [[ ${{ env.version_major }} == *"v2"* ]] && packer_source="${packer_source}_v2"
+            [[ ${{ inputs.variant }} == *"64k"* ]] && packer_source="almalinux_${{ env.version_major }}_${{ inputs.type }}_64k_${{ env.alma_arch }}"
             output_mask=output-${packer_source}/AlmaLinux-*.${{ env.alma_arch }}*.raw
             packer_source=qemu.${packer_source}
             ;;
           digitalocean*)
-            output_mask=output-${packer_source}/AlmaLinux-${version_major}-DigitalOcean-*.${{ env.alma_arch }}.qcow2
+            output_mask=output-${packer_source}/AlmaLinux-${{ env.version_major }}-DigitalOcean-*.${{ env.alma_arch }}.qcow2
             packer_source=qemu.${packer_source}
             # TODO: Exclude digitalocean-import post-processor because of lack of DigitalOcean API token
             # Operating System Version test fails for almaLinux 8.10. Need to refresh from the official repository
@@ -143,78 +147,84 @@ runs:
             sed -i '/role: pvgrub_config/d' ansible/roles/digitalocean_guest/meta/main.yml
             ;;
           vagrant_libvirt8)
-            packer_source=qemu.almalinux-${version_major}
-            output_mask=AlmaLinux-${version_major}-Vagrant-*.${{ env.alma_arch }}.libvirt.box
-            aws_s3_path=images/${version_major}/${release}/vagrant/${{ env.TIME_STAMP }}
+            packer_source=qemu.almalinux-${{ env.version_major }}
+            output_mask=AlmaLinux-${{ env.version_major }}-Vagrant-*.${{ env.alma_arch }}.libvirt.box
+            aws_s3_path=images/${{ env.version_major }}/${release}/vagrant/${{ env.TIME_STAMP }}
             ;;
           vagrant_libvirt9)
-            packer_source=qemu.almalinux-${version_major}
-            output_mask=AlmaLinux-${version_major}-Vagrant-libvirt-*.${{ env.alma_arch }}.box
-            aws_s3_path=images/${version_major}/${release}/vagrant/${{ env.TIME_STAMP }}
+            packer_source=qemu.almalinux-${{ env.version_major }}
+            output_mask=AlmaLinux-${{ env.version_major }}-Vagrant-libvirt-*.${{ env.alma_arch }}.box
+            aws_s3_path=images/${{ env.version_major }}/${release}/vagrant/${{ env.TIME_STAMP }}
             ;;
-          vagrant_libvirt10*)
-            packer_source=qemu.almalinux_${version_major}_vagrant_libvirt_${{ env.alma_arch }}
-            output_mask=AlmaLinux-${version_major}-Vagrant-libvirt-*.${{ env.alma_arch }}.box
-            aws_s3_path=images/${version_major}/${release}/vagrant/${{ env.TIME_STAMP }}
+          vagrant_libvirt10)
+            packer_source=qemu.almalinux_${{ env.version_major }}_vagrant_libvirt_${{ env.alma_arch }}
+            output_mask=AlmaLinux-${{ env.version_major }}-Vagrant-libvirt-*.${{ env.alma_arch }}.box
+            aws_s3_path=images/${{ env.version_major }}/${release}/vagrant/${{ env.TIME_STAMP }}
             ;;
           vagrant_virtualbox8)
-            packer_source=virtualbox-iso.almalinux-${version_major}
+            packer_source=virtualbox-iso.almalinux-${{ env.version_major }}
             packer_opts=
-            output_mask=AlmaLinux-${version_major}-Vagrant-*.${{ env.alma_arch }}.virtualbox.box
-            aws_s3_path=images/${version_major}/${release}/vagrant/${{ env.TIME_STAMP }}
+            output_mask=AlmaLinux-${{ env.version_major }}-Vagrant-*.${{ env.alma_arch }}.virtualbox.box
+            aws_s3_path=images/${{ env.version_major }}/${release}/vagrant/${{ env.TIME_STAMP }}
             ;;
           vagrant_virtualbox9)
-            packer_source=virtualbox-iso.almalinux-${version_major}
+            packer_source=virtualbox-iso.almalinux-${{ env.version_major }}
             packer_opts=
-            output_mask=AlmaLinux-${version_major}-Vagrant-virtualbox-*.${{ env.alma_arch }}.box
-            aws_s3_path=images/${version_major}/${release}/vagrant/${{ env.TIME_STAMP }}
+            output_mask=AlmaLinux-${{ env.version_major }}-Vagrant-virtualbox-*.${{ env.alma_arch }}.box
+            aws_s3_path=images/${{ env.version_major }}/${release}/vagrant/${{ env.TIME_STAMP }}
             ;;
           vagrant_virtualbox10)
-            packer_source=virtualbox-iso.almalinux_${version_major}_vagrant_virtualbox_${{ env.alma_arch }}
+            packer_source=virtualbox-iso.almalinux_${{ env.version_major }}_vagrant_virtualbox_${{ env.alma_arch }}
             packer_opts=
-            output_mask=AlmaLinux-${version_major}-Vagrant-virtualbox-*.${{ env.alma_arch }}.box
-            aws_s3_path=images/${version_major}/${release}/vagrant/${{ env.TIME_STAMP }}
+            output_mask=AlmaLinux-${{ env.version_major }}-Vagrant-virtualbox-*.${{ env.alma_arch }}.box
+            aws_s3_path=images/${{ env.version_major }}/${release}/vagrant/${{ env.TIME_STAMP }}
             ;;
           vagrant_vmware8)
-            packer_source=vmware-iso.almalinux-${version_major}
+            packer_source=vmware-iso.almalinux-${{ env.version_major }}
             packer_opts=
-            output_mask=AlmaLinux-${version_major}-Vagrant-*.${{ env.alma_arch }}.vmware.box
-            aws_s3_path=images/${version_major}/${release}/vagrant/${{ env.TIME_STAMP }}
+            output_mask=AlmaLinux-${{ env.version_major }}-Vagrant-*.${{ env.alma_arch }}.vmware.box
+            aws_s3_path=images/${{ env.version_major }}/${release}/vagrant/${{ env.TIME_STAMP }}
             ;;
           vagrant_vmware9)
-            packer_source=vmware-iso.almalinux-${version_major}
+            packer_source=vmware-iso.almalinux-${{ env.version_major }}
             packer_opts=
-            output_mask=AlmaLinux-${version_major}-Vagrant-vmware-*.${{ env.alma_arch }}.box
-            aws_s3_path=images/${version_major}/${release}/vagrant/${{ env.TIME_STAMP }}
+            output_mask=AlmaLinux-${{ env.version_major }}-Vagrant-vmware-*.${{ env.alma_arch }}.box
+            aws_s3_path=images/${{ env.version_major }}/${release}/vagrant/${{ env.TIME_STAMP }}
             ;;
           vagrant_vmware10)
-            packer_source=vmware-iso.almalinux_${version_major}_vagrant_vmware_${{ env.alma_arch }}
+            packer_source=vmware-iso.almalinux_${{ env.version_major }}_vagrant_vmware_${{ env.alma_arch }}
             packer_opts=
-            output_mask=AlmaLinux-${version_major}-Vagrant-vmware-*.${{ env.alma_arch }}.box
-            aws_s3_path=images/${version_major}/${release}/vagrant/${{ env.TIME_STAMP }}
+            output_mask=AlmaLinux-${{ env.version_major }}-Vagrant-vmware-*.${{ env.alma_arch }}.box
+            aws_s3_path=images/${{ env.version_major }}/${release}/vagrant/${{ env.TIME_STAMP }}
+            ;;
+          vagrant_vmware*kitten*)
+            packer_source=vmware-iso.almalinux_kitten_10_vagrant_vmware_${{ env.alma_arch }}
+            packer_opts=
+            output_mask=AlmaLinux-Kitten-Vagrant-vmware-10-*.${{ env.alma_arch }}.box
+            aws_s3_path=images/kitten/10/vagrant/${{ env.TIME_STAMP }}
             ;;
           vagrant_libvirt*kitten*)
             packer_source=qemu.almalinux_kitten_10_${{ inputs.type }}_${{ env.alma_arch }}
-            [[ ${version_major} == *"v2"* ]] && packer_source="${packer_source}_v2"
+            [[ ${{ env.version_major }} == *"v2"* ]] && packer_source="${packer_source}_v2"
             output_mask=AlmaLinux-Kitten-Vagrant-libvirt-10-*.${{ env.alma_arch }}*.box
             aws_s3_path=images/kitten/10/vagrant/${{ env.TIME_STAMP }}
             ;;
           vagrant_virtualbox*kitten*)
             packer_source=virtualbox-iso.almalinux_kitten_10_${{ inputs.type }}_${{ env.alma_arch }}
-            [[ ${version_major} == *"v2"* ]] && packer_source="${packer_source}_v2"
+            [[ ${{ env.version_major }} == *"v2"* ]] && packer_source="${packer_source}_v2"
             output_mask=AlmaLinux-Kitten-Vagrant-virtualbox-10-*.${{ env.alma_arch }}*.box
             aws_s3_path=images/kitten/10/vagrant/${{ env.TIME_STAMP }}
             ;;
           *kitten*)
             packer_source=almalinux_kitten_10_${{ inputs.type }}_${{ env.alma_arch }}
-            [[ ${version_major} == *"v2"* ]] && packer_source="${packer_source}_v2"
+            [[ ${{ env.version_major }} == *"v2"* ]] && packer_source="${packer_source}_v2"
             output_mask=output-${packer_source}/AlmaLinux-Kitten-*.${{ env.alma_arch }}*.qcow2
             aws_s3_path=images/kitten/10/${{ inputs.type }}/${{ env.TIME_STAMP }}
             packer_source=qemu.${packer_source}
             ;;
           gencloud10|opennebula10)
-            packer_source=almalinux_${version_major}_${{ inputs.type }}_${{ env.alma_arch }}
-            [[ ${version_major} == *"v2"* ]] && packer_source="${packer_source}_v2"
+            packer_source=almalinux_${{ env.version_major }}_${{ inputs.type }}_${{ env.alma_arch }}
+            [[ ${{ env.version_major }} == *"v2"* ]] && packer_source="${packer_source}_v2"
             output_mask=output-${packer_source}/AlmaLinux-*.${{ env.alma_arch }}*.qcow2
             packer_source=qemu.${packer_source}
             ;;
@@ -231,6 +241,8 @@ runs:
         echo "packer_source=${packer_source}" >> $GITHUB_ENV
         echo "output_mask=${output_mask}" >> $GITHUB_ENV
         echo "AWS_S3_PATH=${aws_s3_path}" >> $GITHUB_ENV
+        echo "RELEASE_STRING=${release_string}" >> $GITHUB_ENV
+        echo "RELEASE_PACKAGE=${release_package}" >> $GITHUB_ENV
 
     - name: Install KVM
       if: inputs.type != 'vagrant_virtualbox' && inputs.type != 'vagrant_vmware'
@@ -249,7 +261,7 @@ runs:
         esac
 
     - name: Check nested virtualization support
-      if: inputs.arch == 'x86_64' && inputs.type != 'vagrant_virtualbox' && inputs.type != 'vagrant_vmware'
+      if: inputs.arch == 'x86_64' && inputs.type != 'vagrant_virtualbox' && inputs.type != 'vagrant_vmware' && inputs.runner != 'aws-ec2'
       shell: bash
       run: |
         # Check nested virtualization support
@@ -275,7 +287,7 @@ runs:
       with:
         repo: deb [arch=amd64] https://download.virtualbox.org/virtualbox/debian ${{ env.UBUNTU_CODENAME }} contrib
         repo-name: virtualbox
-        keys-asc: https://www.virtualbox.org/download/oracle_vbox_2016.asc
+        keys-asc: https://download.virtualbox.org/virtualbox/debian/oracle_vbox_2016.asc
         update: true
         install: virtualbox-7.1
 
@@ -286,13 +298,14 @@ runs:
         # Install VMware
         export ws_version=17.6.3
         export ws_build=24583834
+        export ws_bundle_path=/actions-runner/_work/cloud-images/
 
         if ! sudo vmware -v 2>/dev/null; then
           # Find VMware installation bundle at /actions-runner/_work/cloud-images path as its direct download is not available anymore
           # Assume the AMI includes it
-          [ ! -f ../VMware-Workstation-Full-${ws_version}-${ws_build}.x86_64.bundle.tar ] && \
-            wget https://softwareupdate-prod.broadcom.com/cds/vmw-desktop/ws/${ws_version}/${ws_build}/linux/core/VMware-Workstation-Full-${ws_version}-${ws_build}.x86_64.bundle.tar || \
-            mv ../VMware-Workstation-Full-${ws_version}-${ws_build}.x86_64.bundle.tar .
+          [ ! -f ${ws_bundle_path}/VMware-Workstation-Full-${ws_version}-${ws_build}.x86_64.bundle.tar ] \
+            && wget https://softwareupdate-prod.broadcom.com/cds/vmw-desktop/ws/${ws_version}/${ws_build}/linux/core/VMware-Workstation-Full-${ws_version}-${ws_build}.x86_64.bundle.tar \
+            || cp -av ${ws_bundle_path}/VMware-Workstation-Full-${ws_version}-${ws_build}.x86_64.bundle.tar .
           tar xf VMware-Workstation-Full-${ws_version}-${ws_build}.x86_64.bundle.tar && rm -f VMware-Workstation-Full-${ws_version}-${ws_build}.x86_64.bundle.tar
           chmod +x VMware-Workstation-Full-${ws_version}-${ws_build}.x86_64.bundle
 
@@ -436,9 +449,9 @@ runs:
             sudo vagrant up --provider=libvirt
             ;;
         esac
-        # Do simple checking
-        sudo vagrant ssh default -c "cat /etc/almalinux-release | grep 'AlmaLinux release ${{ env.version_major }}'"
-        sudo vagrant ssh default -c "rpm -q --qf='%{ARCH}\n' almalinux-release"
+        echo "[Debug] Do simple checking"
+        sudo vagrant ssh default -c "cat /etc/almalinux-release | grep '${{ env.RELEASE_STRING }}'"
+        sudo vagrant ssh default -c "rpm -q --qf='%{ARCH}\n' ${{ env.RELEASE_PACKAGE }}"
         sudo vagrant ssh default -c "sudo dnf check-update"
         # Get installed packages list
         sudo vagrant ssh default -c "rpm -qa --queryformat '%{NAME}\n' | sort > ${{ env.IMAGE_FILE }}.txt"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: build-images
+name: Build Cloud and Vagrant Images
 
 on:
   workflow_dispatch:
@@ -29,7 +29,7 @@ on:
             - NONE
             - ALL
             - azure
-            - digitalocean        # TODO: require data to work with the cloud, such as: bucket, access key, secret key, etc.
+            # - digitalocean        # TODO: require data to work with the cloud, such as: bucket, access key, secret key, etc.
             - gencloud
             - oci
             - opennebula
@@ -139,11 +139,9 @@ jobs:
             VARIANTS_GH+=("vagrant_libvirt-x86_64")
           fi
           if [ "${{ inputs.vagrant_type }}" = "vagrant_virtualbox" -o "${{ inputs.vagrant_type }}" = "ALL" ]; then
-            [[ "${{ inputs.version_major }}" != *"kitten"*  ]] && \
               VARIANTS_GH+=("vagrant_virtualbox-x86_64") # tests aren't work on GitHub runners, use self-hosted to run tests
           fi
           if [ "${{ inputs.vagrant_type }}" = "vagrant_vmware" -o "${{ inputs.vagrant_type }}" = "ALL" ]; then
-            [[ "${{ inputs.version_major }}" != *"kitten"*  ]] && \
               VARIANTS_SH+=("vagrant_vmware-x86_64") # VMware has networking issues on GitHub runners, so we use self-hosted runner
           fi
 
@@ -188,6 +186,7 @@ jobs:
             variant: '10-kitten-v2'
           - matrix_gh: 'oci-x86_64'
             variant: '10-kitten-v2'
+          # Kitten x86_64_v2 Vagrant for VirtualBox stuck on "Waiting for SSH to become available"
           - matrix_gh: 'vagrant_virtualbox-x86_64'
             variant: '10-kitten-v2'
           - matrix_gh: 'digitalocean-x86_64'
@@ -234,7 +233,10 @@ jobs:
           upload_to_s3: ${{ inputs.upload_to_s3 }}
           notify_mattermost: ${{ inputs.notify_mattermost }}
           run_test: true # Do image simple testing and generate installed packages list (vagrant_* only)
+          # runner: ${{ github.repository_owner == 'AlmaLinux' && 'aws-ec2' || 'gh_hosted' }}
           runner: gh_hosted
+        env:
+          PACKER_GITHUB_API_TOKEN: ${{ secrets.GIT_HUB_TOKEN }}
 
   start-self-hosted-runner:
     name: ${{ matrix.variant }} ${{ matrix.matrix_sh }} runner
@@ -244,13 +246,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        variant: ${{ fromJSON(format('["{0}"]', ( (contains(needs.init-data.outputs.matrix_sh, 'azure-aarch64') && ( inputs.version_major == '9' || inputs.version_major == '10' || inputs.version_major == '10-kitten' ) ) && format('{0}", "{0}-64k', inputs.version_major) || ( ( (inputs.vagrant_type == 'vagrant_vmware' || inputs.vagrant_type == 'ALL') && inputs.version_major == '10' ) && '10", "10-v2' || inputs.version_major ) ) )) }}
+        variant: ${{ fromJSON(format('["{0}"]', ( (contains(needs.init-data.outputs.matrix_sh, 'azure-aarch64') && ( inputs.version_major == '9' || inputs.version_major == '10' || inputs.version_major == '10-kitten' ) ) && format('{0}", "{0}-64k', inputs.version_major) || ( ( (inputs.vagrant_type == 'vagrant_vmware' || inputs.vagrant_type == 'ALL') && ( inputs.version_major == '10' || inputs.version_major == '10-kitten' ) ) && format('{0}", "{0}-v2', inputs.version_major) || inputs.version_major ) ) )) }}
         matrix_sh: ${{ fromJSON(needs.init-data.outputs.matrix_sh) }}
         exclude:
           - matrix_sh: 'oci-aarch64'
             variant: '10-kitten'
-          - matrix_sh: 'oci-aarch64'
-            variant: '10'
           - matrix_sh: 'oci-aarch64'
             variant: '9-64k'
           - matrix_sh: 'oci-aarch64'
@@ -279,7 +279,7 @@ jobs:
 
     steps:
     - name: Setup and start runner
-      if: inputs.self_hosted_runner == 'aws-ec2'
+      if: inputs.self_hosted_runner == 'aws-ec2' && github.repository_owner != 'AlmaLinux'
       uses: NextChapterSoftware/ec2-action-builder@v1.10
       with:
         github_token: ${{ secrets.GIT_HUB_TOKEN }}
@@ -307,17 +307,15 @@ jobs:
     name: ${{ matrix.variant }} ${{ matrix.matrix_sh }} image
     if: ${{ inputs.self-hosted && needs.init-data.outputs.matrix_sh != '[]' }}
     needs: [init-data, start-self-hosted-runner]
-    runs-on: ${{ inputs.self_hosted_runner == 'aws-ec2' && github.run_id || matrix.matrix_sh }}
+    runs-on: ${{ github.repository_owner == 'AlmaLinux' && ( contains(matrix.matrix_sh, 'x86_64') && format('runs-on={0}/family=c5n.metal/ami={1}', github.run_id, vars.EC2_AMI_ID_AL9_X86_64 ) || format('runs-on={0}/family=a1.metal/image=almalinux-9-aarch64', github.run_id) ) || ( inputs.self_hosted_runner == 'aws-ec2' && github.run_id || matrix.matrix_sh ) }}
     strategy:
       fail-fast: false
       matrix:
-        variant: ${{ fromJSON(format('["{0}"]', ( (contains(needs.init-data.outputs.matrix_sh, 'azure-aarch64') && ( inputs.version_major == '9' || inputs.version_major == '10' || inputs.version_major == '10-kitten' ) ) && format('{0}", "{0}-64k', inputs.version_major) || ( ( (inputs.vagrant_type == 'vagrant_vmware' || inputs.vagrant_type == 'ALL') && inputs.version_major == '10' ) && '10", "10-v2' || inputs.version_major ) ) )) }}
+        variant: ${{ fromJSON(format('["{0}"]', ( (contains(needs.init-data.outputs.matrix_sh, 'azure-aarch64') && ( inputs.version_major == '9' || inputs.version_major == '10' || inputs.version_major == '10-kitten' ) ) && format('{0}", "{0}-64k', inputs.version_major) || ( ( (inputs.vagrant_type == 'vagrant_vmware' || inputs.vagrant_type == 'ALL') && ( inputs.version_major == '10' || inputs.version_major == '10-kitten' ) ) && format('{0}", "{0}-v2', inputs.version_major) || inputs.version_major ) ) )) }}
         matrix_sh: ${{ fromJSON(needs.init-data.outputs.matrix_sh) }}
         exclude:
           - matrix_sh: 'oci-aarch64'
             variant: '10-kitten'
-          - matrix_sh: 'oci-aarch64'
-            variant: '10'
           - matrix_sh: 'oci-aarch64'
             variant: '9-64k'
           - matrix_sh: 'oci-aarch64'
@@ -383,4 +381,6 @@ jobs:
           upload_to_s3: ${{ inputs.upload_to_s3 }}
           notify_mattermost: ${{ inputs.notify_mattermost }}
           run_test: true # Do image simple testing and generate installed packages list (vagrant_* only)
-          runner: self_hosted
+          runner: ${{ github.repository_owner == 'AlmaLinux' && 'aws-ec2' || 'self_hosted' }}
+        env:
+          PACKER_GITHUB_API_TOKEN: ${{ secrets.GIT_HUB_TOKEN }}


### PR DESCRIPTION
- `major_version` usage fixes
- add `RELEASE_PACKAGE` and `RELEASE_STRING` environment variables
- fix Vagrant images testing when checking release name and package
- enable Vagrant for VirtualBox and VMware (including `x86_64_v2`) **Kitten 10** images building
- enable OCI `aarch64` **AlmaLinux 10** image building
- remove DigitalOcean images option from the list
- change location of `oracle_vbox_2016.asc` file when configuring VirtualBox for Ubuntu packages repository
- set `PACKER_GITHUB_API_TOKEN` environment variable for `actions/shared-steps`