### PR TITLE
Update azure_uploader.sh

### DIFF
--- a/tools/azure_uploader.sh
+++ b/tools/azure_uploader.sh
@@ -487,7 +487,18 @@ main() {
   local -r blob_name="${image_name}.vhd"
   # convert input image to fixed VHD blob with size rounded to 1 MB
   local -r blob_size="$(get_rounded_size "${INPUT_IMAGE}")"
+  #execute qemu-img resize -q -f raw "${INPUT_IMAGE}" "${blob_size}"
+  # Get actual image size in bytes
+local actual_size
+actual_size=$(qemu-img info -f raw --output json "${INPUT_IMAGE}" | jq '.["virtual-size"]')
+
+# Only resize if needed
+if [ "$actual_size" -ne "$blob_size" ]; then
   execute qemu-img resize -q -f raw "${INPUT_IMAGE}" "${blob_size}"
+else
+  echo "Image already aligned to $blob_size, skipping resize."
+fi
+
   execute qemu-img convert -f raw -o subformat=fixed,force_size -O vpc \
     "${INPUT_IMAGE}" "${blob_name}"
   local -r blob_md5="$(get_blob_md5 "${blob_name}")"


### PR DESCRIPTION
fix(azure_uploader.sh): skip resizing if image already aligned

Attempted to resolve issue #260  by checking the actual image size before running `qemu-img resize`. If the image is already aligned to the required 1MB boundary, the resize step is skipped.

I’m still learning and wanted to try contributing 
If this approach is not correct or can be improved, please don’t hesitate
to let me know — I’ll be happy to make changes.
