### PR TITLE
fix(cleanup): remove NetworkManager system connection files

### DIFF
--- a/ansible/roles/cleanup_vm/tasks/main.yml
+++ b/ansible/roles/cleanup_vm/tasks/main.yml
@@ -19,6 +19,20 @@
   loop_control:
     label: "{{ item.path }}"
 
+- name: Find NetworkManager system connection files
+  ansible.builtin.find:
+    paths: /etc/NetworkManager/system-connections
+    patterns: "*.nmconnection"
+  register: networkmanager_system_connection_files
+
+- name: Delete found NetworkManager system connection files
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ networkmanager_system_connection_files.files }}"
+  loop_control:
+    label: "{{ item.path }}"
+
 - name: Delete DNF cache
   command: dnf clean all
 


### PR DESCRIPTION
The images contained the following
`/etc/NetworkManager/system-connections/eth0.nmconnection` file:
```
[connection]
id=eth0
uuid=84c16fb4-cc79-4e23-9e91-878482c30dee
type=ethernet
autoconnect-priority=-100
autoconnect-retries=1
interface-name=eth0

[ethernet]

[ipv4]
dhcp-timeout=90
dhcp-vendor-class-identifier=anaconda-Linux
method=auto
required-timeout=20000

[ipv6]
addr-gen-mode=eui64
dhcp-timeout=90
method=auto

[proxy]

[user]
org.freedesktop.NetworkManager.origin=nm-initrd-generator
```

The presence of this file could cause `NetworkManager-wait-online.service` to fail when `eth0` existed and could not be configured with DHCPv4.

To avoid future issues, let's remove all NetworkManager system connection files.