### PR TITLE
fix(10): remove console=ttyS0,115200n8 kernel commandline parameter on Vagrant kickstarts

### DIFF
--- a/http/almalinux-10.vagrant-aarch64.ks
+++ b/http/almalinux-10.vagrant-aarch64.ks
@@ -9,7 +9,7 @@ selinux --enforcing
 firewall --disabled
 services --enabled=sshd
 
-bootloader --timeout=0 --location=mbr --append="console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0"
+bootloader --timeout=0 --location=mbr --append="console=tty0 no_timer_check net.ifnames=0"
 
 zerombr
 clearpart --all --initlabel

--- a/http/almalinux-10.vagrant-x86_64.ks
+++ b/http/almalinux-10.vagrant-x86_64.ks
@@ -9,7 +9,7 @@ selinux --enforcing
 firewall --disabled
 services --enabled=sshd
 
-bootloader --timeout=0 --location=mbr --append="console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0"
+bootloader --timeout=0 --location=mbr --append="console=tty0 no_timer_check net.ifnames=0"
 
 %pre --erroronfail
 parted -s -a optimal /dev/sda -- mklabel gpt

--- a/http/almalinux-10.vagrant-x86_64_v2.ks
+++ b/http/almalinux-10.vagrant-x86_64_v2.ks
@@ -9,7 +9,7 @@ selinux --enforcing
 firewall --disabled
 services --enabled=sshd
 
-bootloader --timeout=0 --location=mbr --append="console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0"
+bootloader --timeout=0 --location=mbr --append="console=tty0 no_timer_check net.ifnames=0"
 
 %pre --erroronfail
 parted -s -a optimal /dev/sda -- mklabel gpt


### PR DESCRIPTION
AlmaLinux 10.0 serial getty (on ttyS0) segfaults, on Vagrant for Hyper-V, VirtualBox and VMware guests.
```
Nov 12 08:15:55 localhost kernel: agetty[786]: segfault at 0 ip 00007f0212d082dc sp 00007ffc697281c8 error 4 in libc.so.6[1802dc,7f0212bb0000+16c000] likely on CPU 1 (core 1, socket 0)
```
Vagrant for Libvirt (Qemu) looks fine.

RedHat has solution (UNVERIFIED) for that: https://access.redhat.com/solutions/7127158
They state to ensure there is actually a connected serial console device on the serial port of the system.

Vagrant for Hyper-V, VirtualBox and VMware guests have no such device attached:
```
# cat /proc/tty/driver/serial
serinfo:1.0 driver revision:
0: uart:unknown port:000003F8 irq:4
1: uart:unknown port:000002F8 irq:3
2: uart:unknown port:000003E8 irq:4
3: uart:unknown port:000002E8 irq:3
```
But kernel's commandline parameters include `console=ttyS0,115200n8`

The PR removes the paramerer.