### PR TITLE
feat(hyperv): implement Hyper-V image build via QEMU/KVM

### DIFF
--- a/.github/actions/shared-steps/action.yml
+++ b/.github/actions/shared-steps/action.yml
@@ -111,6 +111,28 @@ runs:
             output_mask=output-${packer_source}/AlmaLinux-*${{ env.version_major }}*.${{ env.alma_arch }}.raw
             packer_source=qemu.${packer_source}
             ;;
+          hyperv8)
+            packer_source=almalinux-${{ env.version_major }}-hyperv-${{ env.alma_arch }}
+            output_mask=AlmaLinux-${{ env.version_major }}-Vagrant-*.${{ env.alma_arch }}.hyperv.box
+            packer_source=qemu.${packer_source}
+            ;;
+          hyperv9)
+            output_mask=AlmaLinux-${{ env.version_major }}-Vagrant-hyperv-*.${{ env.alma_arch }}.box
+            packer_source=qemu.${packer_source}
+            ;;
+          hyperv10)
+            packer_source=almalinux_10_vagrant_hyperv_${{ env.alma_arch }}
+            [[ ${{ env.version_major }} == *"v2"* ]] && packer_source="${packer_source}_v2"
+            output_mask=AlmaLinux-${{ env.version_major }}-Vagrant-hyperv-*.${{ env.alma_arch }}.box
+            packer_source=qemu.${packer_source}
+            ;;
+          hyperv*kitten*)
+            packer_source=almalinux_kitten_10_vagrant_hyperv_${{ env.alma_arch }}
+            [[ ${{ env.version_major }} == *"v2"* ]] && packer_source="${packer_source}_v2"
+            output_mask=AlmaLinux-Kitten-Vagrant-hyperv-10-*.${{ env.alma_arch }}.box
+            aws_s3_path=images/kitten/10/vagrant/${{ env.TIME_STAMP }}
+            packer_source=qemu.${packer_source}
+            ;;
           azure*kitten*)
             packer_source=almalinux_kitten_10_${{ inputs.type }}_${{ env.alma_arch }}
             [[ ${{ env.version_major }} == *"v2"* ]] && packer_source="${packer_source}_v2"
@@ -394,9 +416,20 @@ runs:
         esac
 
         # Image file format: raw or qcow2
+        # Image file name is redefined for the Hyper-V, as it is build using Qemu and converted to .box file
         case ${{ inputs.type }} in
-          oci|gencloud|opennebula) format=qcow2 ;;
-          azure) format=raw ;;
+          oci|gencloud|opennebula)
+            format=qcow2
+            image_file=${{ env.IMAGE_FILE }}
+            ;;
+          hyperv)
+            format=raw
+            image_file=$(echo ${{ env.IMAGE_FILE }} | sed 's/\.box$/.raw/')
+            ;;
+          azure)
+            format=raw
+            image_file=${{ env.IMAGE_FILE }}
+            ;;
           *) false ;;
         esac
         rootfs_path=/mnt/rootfs
@@ -411,14 +444,14 @@ runs:
         sudo modprobe nbd max_part=8
 
         # Make a copy of the image file
-        sudo cp ${{ env.IMAGE_FILE }} $(dirname ${rootfs_path})
+        sudo cp ${image_file} $(dirname ${rootfs_path})
 
         # Attach the image file to the nbd device
         sudo qemu-nbd \
           --read-only \
           --format=${format} \
           --connect=/dev/nbd0 \
-          $(dirname ${rootfs_path})/$(basename ${{ env.IMAGE_FILE }}) \
+          $(dirname ${rootfs_path})/$(basename ${image_file}) \
           && sleep 10 || false
 
         # Mount need partition

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ on:
             - azure
             # - digitalocean        # TODO: require data to work with the cloud, such as: bucket, access key, secret key, etc.
             - gencloud
+            - hyperv
             - oci
             - opennebula
 
@@ -128,6 +129,9 @@ jobs:
           if [ "${{ inputs.image_type }}" = "opennebula" -o "${{ inputs.image_type }}" = "ALL" ]; then
             VARIANTS_GH+=("opennebula-x86_64")
             VARIANTS_SH+=("opennebula-aarch64")
+          fi
+          if [ "${{ inputs.image_type }}" = "hyperv" -o "${{ inputs.vagrant_type }}" = "ALL" ]; then
+            VARIANTS_GH+=("hyperv-x86_64")
           fi
 
           # Vagrant Images

--- a/almalinux-9-vagrant.pkr.hcl
+++ b/almalinux-9-vagrant.pkr.hcl
@@ -78,6 +78,37 @@ source "hyperv-iso" "almalinux-9" {
   headless              = var.headless
 }
 
+source "qemu" "almalinux-9-hyperv-x86_64" {
+  iso_url            = local.iso_url_9_x86_64
+  iso_checksum       = local.iso_checksum_9_x86_64
+  http_directory     = var.http_directory
+  shutdown_command   = var.vagrant_shutdown_command
+  ssh_username       = var.vagrant_ssh_username
+  ssh_password       = var.vagrant_ssh_password
+  ssh_timeout        = var.ssh_timeout
+  boot_command       = var.hyperv_boot_command_9_x86_64
+  boot_wait          = var.boot_wait
+  accelerator        = "kvm"
+  disk_interface     = "virtio-scsi"
+  disk_size          = var.vagrant_disk_size
+  disk_cache         = "unsafe"
+  disk_discard       = "unmap"
+  disk_detect_zeroes = "unmap"
+  format             = "raw"
+  headless           = var.headless
+  machine_type       = "q35"
+  memory             = var.memory_x86_64
+  net_device         = "virtio-net"
+  qemu_binary        = var.qemu_binary
+  vm_name            = "almalinux-9-hyperv-x86_64.raw"
+  cpu_model          = "host"
+  cpus               = var.cpus
+  efi_boot           = true
+  efi_firmware_code  = var.ovmf_code
+  efi_firmware_vars  = var.ovmf_vars
+  efi_drop_efivars   = true
+}
+
 source "vmware-iso" "almalinux-9" {
   iso_url                        = local.iso_url_9_x86_64
   iso_checksum                   = local.iso_checksum_9_x86_64
@@ -193,6 +224,7 @@ build {
     "source.qemu.almalinux-9",
     "source.virtualbox-iso.almalinux-9",
     "source.hyperv-iso.almalinux-9",
+    "source.qemu.almalinux-9-hyperv-x86_64",
     "source.vmware-iso.almalinux-9",
     "source.parallels-iso.almalinux-9",
     "source.virtualbox-iso.almalinux-9-aarch64",
@@ -248,10 +280,34 @@ build {
     only = ["hyperv-iso.almalinux-9"]
   }
 
+  provisioner "ansible" {
+    user                 = "vagrant"
+    use_proxy            = false
+    galaxy_file          = "./ansible/requirements.yml"
+    galaxy_force_install = true
+    collections_path     = "./ansible/collections"
+    roles_path           = "./ansible/roles"
+    playbook_file        = "./ansible/hyperv.yml"
+    ansible_env_vars = [
+      "ANSIBLE_PIPELINING=True",
+      "ANSIBLE_REMOTE_TEMP=/tmp",
+      "ANSIBLE_SCP_EXTRA_ARGS=-O",
+      "ANSIBLE_HOST_KEY_CHECKING=False",
+    ]
+    extra_arguments = [
+      "--extra-vars",
+      "packer_provider=${source.type} ansible_ssh_pass=vagrant",
+    ]
+    only = ["qemu.almalinux-9-hyperv-x86_64"]
+  }
+
   provisioner "shell" {
     expect_disconnect = true
     inline            = ["sudo rm -fr /etc/ssh/*host*key*"]
-    only              = ["hyperv-iso.almalinux-9"]
+    only              = [
+      "hyperv-iso.almalinux-9",
+      "qemu.almalinux-9-hyperv-x86_64",
+    ]
   }
 
   post-processors {
@@ -283,5 +339,21 @@ build {
       output               = "AlmaLinux-9-Vagrant-{{.Provider}}-${var.os_ver_9}-${formatdate("YYYYMMDD", timestamp())}.x86_64.box"
       only                 = ["qemu.almalinux-9"]
     }
+
+    post-processor "shell-local" {
+      inline = [
+        "tools/raw-to-vagrant-hyperv.sh ${source.name} AlmaLinux-9-Vagrant-hyperv-${var.os_ver_9}-${formatdate("YYYYMMDD", timestamp())}.x86_64",
+      ]
+      only = ["qemu.almalinux-9-hyperv-x86_64"]
+    }
+
+    post-processor "artifice" {
+      files = [
+        "AlmaLinux-9-Vagrant-hyperv-${var.os_ver_9}-${formatdate("YYYYMMDD", timestamp())}.x86_64.box",
+        "AlmaLinux-9-Vagrant-hyperv-${var.os_ver_9}-${formatdate("YYYYMMDD", timestamp())}.x86_64.raw",
+      ]
+      only = ["qemu.almalinux-9-hyperv-x86_64"]
+    }
+
   }
 }

--- a/almalinux_kitten_10_vagrant.pkr.hcl
+++ b/almalinux_kitten_10_vagrant.pkr.hcl
@@ -21,6 +21,37 @@ source "hyperv-iso" "almalinux_kitten_10_vagrant_hyperv_x86_64" {
   headless              = var.headless
 }
 
+source "qemu" "almalinux_kitten_10_vagrant_hyperv_x86_64" {
+  iso_url            = var.iso_url_kitten_10_x86_64
+  iso_checksum       = var.iso_checksum_kitten_10_x86_64
+  http_directory     = var.http_directory
+  shutdown_command   = var.vagrant_shutdown_command
+  ssh_username       = var.vagrant_ssh_username
+  ssh_password       = var.vagrant_ssh_password
+  ssh_timeout        = var.ssh_timeout
+  boot_command       = var.hyperv_boot_command_kitten_10_x86_64
+  boot_wait          = var.boot_wait
+  accelerator        = "kvm"
+  disk_interface     = "virtio-scsi"
+  disk_size          = var.vagrant_disk_size
+  disk_cache         = "unsafe"
+  disk_discard       = "unmap"
+  disk_detect_zeroes = "unmap"
+  format             = "raw"
+  headless           = var.headless
+  machine_type       = "q35"
+  memory             = var.memory_x86_64
+  net_device         = "virtio-net"
+  qemu_binary        = var.qemu_binary
+  vm_name            = "almalinux_kitten_10_vagrant_hyperv_x86_64.raw"
+  cpu_model          = "host"
+  cpus               = var.cpus
+  efi_boot           = true
+  efi_firmware_code  = var.ovmf_code
+  efi_firmware_vars  = var.ovmf_vars
+  efi_drop_efivars   = true
+}
+
 source "qemu" "almalinux_kitten_10_vagrant_libvirt_x86_64" {
   iso_url            = var.iso_url_kitten_10_x86_64
   iso_checksum       = var.iso_checksum_kitten_10_x86_64
@@ -192,6 +223,37 @@ source "hyperv-iso" "almalinux_kitten_10_vagrant_hyperv_x86_64_v2" {
   headless              = var.headless
 }
 
+source "qemu" "almalinux_kitten_10_vagrant_hyperv_x86_64_v2" {
+  iso_url            = var.iso_url_kitten_10_x86_64_v2
+  iso_checksum       = var.iso_checksum_kitten_10_x86_64_v2
+  http_directory     = var.http_directory
+  shutdown_command   = var.vagrant_shutdown_command
+  ssh_username       = var.vagrant_ssh_username
+  ssh_password       = var.vagrant_ssh_password
+  ssh_timeout        = var.ssh_timeout
+  boot_command       = var.hyperv_boot_command_kitten_10_x86_64_v2
+  boot_wait          = var.boot_wait
+  accelerator        = "kvm"
+  disk_interface     = "virtio-scsi"
+  disk_size          = var.vagrant_disk_size
+  disk_cache         = "unsafe"
+  disk_discard       = "unmap"
+  disk_detect_zeroes = "unmap"
+  format             = "raw"
+  headless           = var.headless
+  machine_type       = "q35"
+  memory             = var.memory_x86_64
+  net_device         = "virtio-net"
+  qemu_binary        = var.qemu_binary
+  vm_name            = "almalinux_kitten_10_vagrant_hyperv_x86_64_v2.raw"
+  cpu_model          = "host"
+  cpus               = var.cpus
+  efi_boot           = true
+  efi_firmware_code  = var.ovmf_code
+  efi_firmware_vars  = var.ovmf_vars
+  efi_drop_efivars   = true
+}
+
 source "qemu" "almalinux_kitten_10_vagrant_libvirt_x86_64_v2" {
   iso_url            = var.iso_url_kitten_10_x86_64_v2
   iso_checksum       = var.iso_checksum_kitten_10_x86_64_v2
@@ -281,6 +343,7 @@ source "vmware-iso" "almalinux_kitten_10_vagrant_vmware_x86_64_v2" {
 build {
   sources = [
     "source.hyperv-iso.almalinux_kitten_10_vagrant_hyperv_x86_64",
+    "source.qemu.almalinux_kitten_10_vagrant_hyperv_x86_64",
     "source.qemu.almalinux_kitten_10_vagrant_libvirt_x86_64",
     "source.virtualbox-iso.almalinux_kitten_10_vagrant_virtualbox_x86_64",
     "source.vmware-iso.almalinux_kitten_10_vagrant_vmware_x86_64",
@@ -288,6 +351,7 @@ build {
     "source.virtualbox-iso.almalinux_kitten_10_vagrant_virtualbox_aarch64",
     "source.vmware-iso.almalinux_kitten_10_vagrant_vmware_aarch64",
     "source.hyperv-iso.almalinux_kitten_10_vagrant_hyperv_x86_64_v2",
+    "source.qemu.almalinux_kitten_10_vagrant_hyperv_x86_64_v2",
     "source.qemu.almalinux_kitten_10_vagrant_libvirt_x86_64_v2",
     "source.virtualbox-iso.almalinux_kitten_10_vagrant_virtualbox_x86_64_v2",
     "source.vmware-iso.almalinux_kitten_10_vagrant_vmware_x86_64_v2",
@@ -317,12 +381,38 @@ build {
     ]
   }
 
+  provisioner "ansible" {
+    user                 = "vagrant"
+    use_proxy            = false
+    galaxy_file          = "./ansible/requirements.yml"
+    galaxy_force_install = true
+    collections_path     = "./ansible/collections"
+    roles_path           = "./ansible/roles"
+    playbook_file        = "./ansible/hyperv.yml"
+    ansible_env_vars = [
+      "ANSIBLE_PIPELINING=True",
+      "ANSIBLE_REMOTE_TEMP=/tmp",
+      "ANSIBLE_SCP_EXTRA_ARGS=-O",
+      "ANSIBLE_HOST_KEY_CHECKING=False",
+    ]
+    extra_arguments = [
+      "--extra-vars",
+      "packer_provider=${source.type} ansible_ssh_pass=vagrant",
+    ]
+    only = [
+      "qemu.almalinux_kitten_10_vagrant_hyperv_x86_64",
+      "qemu.almalinux_kitten_10_vagrant_hyperv_x86_64_v2",
+    ]
+  }
+
   provisioner "shell" {
     expect_disconnect = true
     inline            = ["sudo rm -fr /etc/ssh/*host*key*"]
     only = [
       "hyperv-iso.almalinux_kitten_10_vagrant_hyperv_x86_64",
       "hyperv-iso.almalinux_kitten_10_vagrant_hyperv_x86_64_v2",
+      "qemu.almalinux_kitten_10_vagrant_hyperv_x86_64",
+      "qemu.almalinux_kitten_10_vagrant_hyperv_x86_64_v2",
     ]
   }
 
@@ -400,5 +490,36 @@ build {
       output               = "AlmaLinux-Kitten-Vagrant-{{.Provider}}-10-${formatdate("YYYYMMDD", timestamp())}.${var.build_number}.x86_64_v2.box"
       only                 = ["qemu.almalinux_kitten_10_vagrant_libvirt_x86_64_v2"]
     }
+
+    post-processor "shell-local" {
+      inline = [
+        "tools/raw-to-vagrant-hyperv.sh ${source.name} AlmaLinux-Kitten-Vagrant-hyperv-10-${formatdate("YYYYMMDD", timestamp())}.${var.build_number}.x86_64"
+      ]
+      only = ["qemu.almalinux_kitten_10_vagrant_hyperv_x86_64"]
+    }
+
+    post-processor "shell-local" {
+      inline = [
+        "tools/raw-to-vagrant-hyperv.sh ${source.name} AlmaLinux-Kitten-Vagrant-hyperv-10-${formatdate("YYYYMMDD", timestamp())}.${var.build_number}.x86_64_v2"
+      ]
+      only = ["qemu.almalinux_kitten_10_vagrant_hyperv_x86_64_v2"]
+    }
+
+    post-processor "artifice" {
+      files = [
+        "AlmaLinux-Kitten-Vagrant-hyperv-10-${formatdate("YYYYMMDD", timestamp())}.${var.build_number}.x86_64.box",
+        "AlmaLinux-Kitten-Vagrant-hyperv-10-${formatdate("YYYYMMDD", timestamp())}.${var.build_number}.x86_64.raw",
+      ]
+      only = ["qemu.almalinux_kitten_10_vagrant_hyperv_x86_64"]
+    }
+
+    post-processor "artifice" {
+      files = [
+        "AlmaLinux-Kitten-Vagrant-hyperv-10-${formatdate("YYYYMMDD", timestamp())}.${var.build_number}.x86_64_v2.box",
+        "AlmaLinux-Kitten-Vagrant-hyperv-10-${formatdate("YYYYMMDD", timestamp())}.${var.build_number}.x86_64_v2.raw",
+      ]
+      only = ["qemu.almalinux_kitten_10_vagrant_hyperv_x86_64_v2"]
+    }
+
   }
 }

--- a/ansible/hyperv.yml
+++ b/ansible/hyperv.yml
@@ -1,0 +1,15 @@
+# An Ansible playbook that configures an AlmaLinux OS Hyper-V image
+---
+- name: AlmaLinux Hyper-V
+  hosts: default
+  become: true
+  collections:
+    - almalinux.ci
+
+  roles:
+    - role: unified_boot
+      vars:
+        unified_boot_kernel_opts: loglevel=3 console=tty1 console=ttyS0 earlyprintk=ttyS0 rootdelay=300 no_timer_check biosdevname=0 net.ifnames=0
+      when: is_unified_boot is defined
+    - vagrant_guest
+    - hyperv_guest

--- a/ansible/roles/hyperv_guest/tasks/main.yml
+++ b/ansible/roles/hyperv_guest/tasks/main.yml
@@ -15,3 +15,14 @@
     - hypervvssd
     - hypervkvpd
     - hypervfcopyd
+
+- name: Delete qemu-guest-agent package
+  ansible.builtin.dnf:
+    name: qemu-guest-agent
+    state: absent
+
+- name: Upgrade initramfs with hv_netvsc and hv_storvsc included
+  ansible.builtin.shell:
+    cmd: dracut -fv --add-drivers " hv_netvsc hv_storvsc " --kver $(rpm -q --queryformat "%{VERSION}-%{RELEASE}.%{ARCH}\n" kernel-core)
+  changed_when: true
+  when: ansible_facts['distribution_major_version'] | int == 8

--- a/tools/raw-to-vagrant-hyperv.sh
+++ b/tools/raw-to-vagrant-hyperv.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# The script creates Vagrant box file for the Hyper-V, with the following content:
+# - Virtual Machines/box.xml, copied from the templated file
+# - Virtual Hard Disks/almalinux.vhdx, converted with qemu-img from the raw image
+# - Vagrantfile, empty file
+# - metadata.json, with the architecture and provider information
+#
+# These files are packed by the tar+gzip to match Vagrant for Hyper-V box format
+#
+# The script is called by the shell-local post-processor from the packer template.
+# The predefined vagrant post-processor is not used, because it skips 'Virtual Machines' and 'Virtual Hard Disks' directories.
+#
+# The raw image is not used by the Hyper-V, but it is kept for the GitHub Actions workflow to extract packages list from it
+
+# Usage:
+#  tools/raw-to-vagrant-hyperv.sh <SOURCE_NAME> <BOX_NAME>
+
+# Source Name, like:
+#  almalinux-8-hyperv-x86_64
+#  almalinux-9-hyperv-x86_64
+#  almalinux_10_vagrant_hyperv_x86_64
+#  almalinux_kitten_10_vagrant_hyperv_x86_64
+source_name=$1
+
+# Box Name, like:
+#  AlmaLinux-8-Vagrant-8.10-YYYYMMDD.x86_64.hyperv
+#  AlmaLinux-9-Vagrant-hyperv-9.6-YYYYMMDD.x86_64
+#  AlmaLinux-10-Vagrant-hyperv-10.0-YYYYMMDD.0.x86_64
+#  AlmaLinux-Kitten-Vagrant-hyperv-10-YYYYMMDD.0.x86_64
+box_name=$2
+
+# Creates:
+#  <BOX_NAME>.box
+#  <BOX_NAME>.raw
+
+mkdir -p "${source_name}/Virtual Machines" "${source_name}/Virtual Hard Disks"
+touch "${source_name}/Vagrantfile"
+echo '{"architecture":"amd64","provider":"hyperv"}' > "${source_name}/metadata.json"
+cp -a ./tpl/vagrant/hyperv/box.xml "${source_name}/Virtual Machines/box.xml"
+qemu-img convert -f raw -O vhdx "output-${source_name}/${source_name}.raw" "${source_name}/Virtual Hard Disks/almalinux.vhdx"
+cd "${source_name}" || exit 1
+tar --use-compress-program='gzip -9' -cvf "../${box_name}.box" .
+cd - > /dev/null 2>&1 || exit 1
+mv "output-${source_name}/${source_name}.raw" "${box_name}.raw"
+rm -rf "${source_name}" "output-${source_name}"

--- a/tpl/vagrant/hyperv/box.xml
+++ b/tpl/vagrant/hyperv/box.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<configuration>
+  <properties>
+    <subtype type="integer">1</subtype>
+    <name type="string">almalinux</name>
+  </properties>
+  <settings>
+    <processors>
+      <count type="integer">2</count>
+    </processors>
+    <memory>
+      <bank>
+        <dynamic_memory_enabled type="bool">True</dynamic_memory_enabled>
+        <limit type="integer">1048576</limit>
+        <reservation type="integer">512</reservation>
+        <size type="integer">3072</size>
+      </bank>
+    </memory>
+  </settings>
+  <AltSwitchName type="string">almalinux</AltSwitchName>
+  <boot>
+    <device0 type="string">HardDrive</device0>
+  </boot>
+  <secure_boot_enabled type="bool">False</secure_boot_enabled>
+  <secure_boot_template type="string">MicrosoftWindows</secure_boot_template>
+  <tpm_enabled type="bool">True</tpm_enabled>
+  <notes type="string">
+  </notes>
+  <vm-controllers>
+    <scsi ChannelInstanceGuid="x">
+      <controller0>
+        <drive0>
+          <pathname type="string">"Virtual Hard Disks\almalinux.vhdx"</pathname>
+          <type type="string">VHD</type>
+        </drive0>
+      </controller0>
+    </scsi>
+  </vm-controllers>
+</configuration>

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -1179,6 +1179,131 @@ variable "hyperv_switch_name" {
   default = null
 }
 
+variable "hyperv_boot_command_8_x86_64" {
+  description = "Boot command for AlmaLinux OS 8 Hyper-V x86_64"
+
+  type = list(string)
+
+  default = [
+    "e",
+    "<down><down>",
+    "<leftCtrlOn>e<leftCtrlOff>",
+    "<spacebar>",
+    "biosdevname=0",
+    "<spacebar>",
+    "net.ifnames=0",
+    "<spacebar>",
+    "inst.text",
+    "<spacebar>",
+    "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-8.vagrant-x86_64.ks",
+    "<leftCtrlOn>x<leftCtrlOff>",
+  ]
+}
+
+variable "hyperv_boot_command_9_x86_64" {
+  description = "Boot command for AlmaLinux OS 9 Hyper-V x86_64"
+
+  type = list(string)
+
+  default = [
+    "e",
+    "<down><down>",
+    "<leftCtrlOn>e<leftCtrlOff>",
+    "<spacebar>",
+    "biosdevname=0",
+    "<spacebar>",
+    "net.ifnames=0",
+    "<spacebar>",
+    "inst.text",
+    "<spacebar>",
+    "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-9.vagrant-x86_64.ks",
+    "<leftCtrlOn>x<leftCtrlOff>",
+  ]
+}
+
+variable "hyperv_boot_command_kitten_10_x86_64" {
+  description = "Boot command for AlmaLinux OS Kitten 10 Hyper-V x86_64"
+
+  type = list(string)
+
+  default = [
+    "e",
+    "<down><down>",
+    "<leftCtrlOn>e<leftCtrlOff>",
+    "<spacebar>",
+    "biosdevname=0",
+    "<spacebar>",
+    "net.ifnames=0",
+    "<spacebar>",
+    "inst.text",
+    "<spacebar>",
+    "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-kitten-10.vagrant-x86_64.ks",
+    "<leftCtrlOn>x<leftCtrlOff>",
+  ]
+}
+
+variable "hyperv_boot_command_kitten_10_x86_64_v2" {
+  description = "Boot command for AlmaLinux OS Kitten 10 Hyper-V x86_64_v2"
+
+  type = list(string)
+
+  default = [
+    "e",
+    "<down><down>",
+    "<leftCtrlOn>e<leftCtrlOff>",
+    "<spacebar>",
+    "biosdevname=0",
+    "<spacebar>",
+    "net.ifnames=0",
+    "<spacebar>",
+    "inst.text",
+    "<spacebar>",
+    "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-kitten-10.vagrant-x86_64_v2.ks",
+    "<leftCtrlOn>x<leftCtrlOff>",
+  ]
+}
+
+variable "hyperv_boot_command_10_x86_64" {
+  description = "Boot command for AlmaLinux OS 10 Hyper-V x86_64"
+
+  type = list(string)
+
+  default = [
+    "e",
+    "<down><down>",
+    "<leftCtrlOn>e<leftCtrlOff>",
+    "<spacebar>",
+    "biosdevname=0",
+    "<spacebar>",
+    "net.ifnames=0",
+    "<spacebar>",
+    "inst.text",
+    "<spacebar>",
+    "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-10.vagrant-x86_64.ks",
+    "<leftCtrlOn>x<leftCtrlOff>",
+  ]
+}
+
+variable "hyperv_boot_command_10_x86_64_v2" {
+  description = "Boot command for AlmaLinux OS 10 Hyper-V x86_64_v2"
+
+  type = list(string)
+
+  default = [
+    "e",
+    "<down><down>",
+    "<leftCtrlOn>e<leftCtrlOff>",
+    "<spacebar>",
+    "biosdevname=0",
+    "<spacebar>",
+    "net.ifnames=0",
+    "<spacebar>",
+    "inst.text",
+    "<spacebar>",
+    "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/almalinux-10.vagrant-x86_64_v2.ks",
+    "<leftCtrlOn>x<leftCtrlOff>",
+  ]
+}
 # Parallels
 
 variable "parallels_tools_flavor_x86_64" {


### PR DESCRIPTION
This introduces an alternative implementation for building Hyper-V Vagrant boxes using QEMU/KVM. This allows Hyper-V images to be built on Linux hosts, removing the dependency on a Windows host running the Hyper-V hypervisor.

To achieve this, the build process produces a RAW disk image via QEMU, which is subsequently converted to VHDX and packaged.

Changes:

- Add new Packer sources (`qemu.almalinux-*-hyperv-x86_64`) for AlmaLinux 8, 9, 10, and Kitten. These sources utilize QEMU/KVM guest definitions combined with Vagrant-specific configurations (boot commands, credentials, and Ansible playbooks).
- Configure a `shell-local` post-processor in Packer to convert the resulting QEMU RAW artifact into a VHDX-based Vagrant box.
- Add `tools/raw-to-vagrant-hyperv.sh` helper script to handle the RAW-to-VHDX conversion and tar+gzip packaging.
- Add `tpl/vagrant/hyperv/box.xml` as the common Vagrant box configuration template for Hyper-V.
- Create `ansible/hyperv.yml` playbook to configure the QEMU guest for Hyper-V compatibility.
- Update `ansible/roles/hyperv_guest/tasks/main.yml` to:
    - Remove the `qemu-guest-agent` package to prevent conflicts.
    - Upgrade `initramfs` to include `hv_netvsc` and `hv_storvsc` drivers (specifically for AL8).
- Extend `variables.pkr.hcl` with `hyperv_boot_command_*_x86_64` variables.

CI:
- Add support for building Hyper-V images as Cloud Images option (non-Vagrant). They are also build with Vagrant Images 'ALL' option.
- Enable package list extraction from the .raw file format.