### PR TITLE
Install and setup cloud-init for Vagrant images

### DIFF
--- a/ansible/roles/vagrant_guest/tasks/main.yaml
+++ b/ansible/roles/vagrant_guest/tasks/main.yaml
@@ -12,6 +12,7 @@
   ansible.builtin.dnf:
     install_weak_deps: "{{ false if ansible_facts['distribution_major_version'] | int >= 9 else omit }}"
     name:
+      - cloud-init
       - cifs-utils
       - jq
       - nfs-utils
@@ -36,3 +37,19 @@
     user: vagrant
     key: "{{ lookup('ansible.builtin.file', 'vagrant.pub') }}"
     state: present
+
+- name: Enable cloud-init services
+  service:
+    name: "{{ item }}"
+    enabled: true
+  with_items:
+    - cloud-config
+    - cloud-init
+    - cloud-init-local
+    - cloud-final
+
+- name: Change cloud-init user to vagrant
+  replace:
+    dest: /etc/cloud/cloud.cfg
+    regexp: '^(\s+name:).*$'
+    replace: '\1 vagrant'


### PR DESCRIPTION
Following a brief discussion on the Mattermost, I've implemented a fix to #299 - I have not implemented this change in the generic cloud image. I've been unable to test the change using `tests/vagrant/` as the version of testinfra doesn't recognise the flags `--hosts=` and `--ssh-config=` on my host.