### PR TITLE
fix(kitten): correct url for Oz and s390x Gencloud image

### DIFF
--- a/almalinux_kitten_10_gencloud_s390x.xml.tmpl
+++ b/almalinux_kitten_10_gencloud_s390x.xml.tmpl
@@ -5,7 +5,7 @@
             <version>1</version>
             <arch>s390x</arch>
             <install type='url'>
-                <url>https://kitten.repo.almalinux.org/10-kitten/BaseOS/s390x/os</url>
+                <url>https://kitten.repo.almalinux.org/10-kitten/BaseOS/s390x/kickstart/</url>
             </install>
       </os>
     <description>AlmaLinux-Kitten-GenericCloud-10-TIMESTAMP.IMGBUILDNUMBER.s390x</description>

--- a/http/almalinux-kitten-10.gencloud-s390x.ks
+++ b/http/almalinux-kitten-10.gencloud-s390x.ks
@@ -182,8 +182,4 @@ cat /dev/null > /etc/machine-id
 # The system should start out with an empty file.
 truncate -s 0 /etc/resolv.conf
 
-# To fix the OpenSSH version 9.9p1-16.el10 issue:
-# ssh: unexpected packet in response to channel open: <nil>
-dnf -y reinstall openssh-server
-
 %end


### PR DESCRIPTION
Do not reinstall `openssh-server` package on the kickstart.