### PR TITLE
chore(ci): use GitHub, Self-hosted runners and RunsOn, generate SBOM if GCP images only

### DIFF
--- a/.github/actions/shared-steps/action.yml
+++ b/.github/actions/shared-steps/action.yml
@@ -1,33 +1,48 @@
 name: "Cloud Image build, upload and notify"
+description: "Builds AlmaLinux cloud images using Packer, runs tests, uploads to S3, and sends notifications"
 
 inputs:
   type:
+    description: 'Image type to build (e.g., azure, gcp, vagrant_libvirt, etc.)'
     required: true
   variant:
+    description: 'AlmaLinux variant to build (e.g., 9, 10, kitten)'
     required: true
   arch:
+    description: 'Target architecture (x86_64 or aarch64)'
     required: true
   S3_ACCESS_KEY_ID:
+    description: 'AWS S3 access key ID for uploading images'
     required: true
   S3_SECRET_ACCESS_KEY:
+    description: 'AWS S3 secret access key for uploading images'
     required: true
   AWS_REGION:
+    description: 'AWS region for S3 bucket'
     required: true
   AWS_S3_BUCKET:
+    description: 'S3 bucket name for storing built images'
     required: true
   MATTERMOST_WEBHOOK_URL:
+    description: 'Mattermost webhook URL for notifications'
     required: true
   MATTERMOST_CHANNEL:
+    description: 'Mattermost channel for notifications'
     required: true
   store_as_artifact:
+    description: 'Whether to store the built image as a GitHub artifact (true/false)'
     required: true
   upload_to_s3:
+    description: 'Whether to upload the built image to S3 (true/false)'
     required: true
   notify_mattermost:
+    description: 'Whether to send notifications to Mattermost (true/false)'
     required: true
   run_test:
+    description: 'Whether to run tests on the built image (true/false)'
     required: true
   runner:
+    description: 'Type of runner to use for the build process'
     required: true
 
 runs:
@@ -112,7 +127,8 @@ runs:
 
         # tell packer we can use more cpu/ram if we're using runs-on
         # which means we're using runs-on with metal instances
-        [[ ${{ env.RUNS_ON_VERSION }} != '' ]] && packer_opts="${packer_opts} -var cpus=$(($(nproc)-4)) -var memory_${{ env.alma_arch }}=32768"
+        # TODO: Error launching VM: Qemu failed to start. Please run with PACKER_LOG=1 to get more info.
+        # [[ "${{ env.RUNS_ON_VERSION }}" != "" ]] && packer_opts="${packer_opts} -var cpus=$(($(nproc)-4)) -var memory_${{ env.alma_arch }}=32768"
 
         # Overriding packer source, image mask and S3 path where necessary
         case "${{ inputs.type }}${{ env.version_major }}" in
@@ -271,24 +287,8 @@ runs:
             ;;
         esac
 
-    - name: Remove KVM
-      if: inputs.type == 'vagrant_virtualbox' || inputs.type == 'vagrant_vmware'
-      shell: bash
-      run: |
-        # Remove KVM
-        case ${{ env.runner_os }} in
-          ubuntu)
-            sudo apt-get -y remove qemu-kvm
-            ;;
-          rhel)
-            sudo dnf -y -q remove qemu-kvm
-            ;;
-        esac
-        sudo rmmod kvm_amd || sudo rmmod kvm_intel || true
-        sudo rmmod kvm || true
-
     - name: Check nested virtualization support
-      if: inputs.arch == 'x86_64' && env.RUNS_ON_VERSION == '' && inputs.type != 'vagrant_virtualbox' && inputs.type != 'vagrant_vmware'
+      if: inputs.arch == 'x86_64' && inputs.type != 'vagrant_virtualbox' && inputs.type != 'vagrant_vmware' && inputs.runner != 'aws-ec2'
       shell: bash
       run: |
         # Check nested virtualization support
@@ -392,12 +392,14 @@ runs:
         sudo ${{ env.runner_os == 'ubuntu' && 'apt-get' || 'dnf -q' }} -y install ansible
 
     - name: Clone SBOM tools
+      if: env.IMAGE_TYPE == 'gcp'
       shell: bash
       run: |
         rm -rf sbom-tools
         git clone --depth=1 https://github.com/AlmaLinux/cloud-images-sbom-tools.git sbom-tools
 
     - name: Set up Python and install generator deps
+      if: env.IMAGE_TYPE == 'gcp'
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
@@ -405,6 +407,7 @@ runs:
         cache-dependency-path: sbom-tools/requirements.txt
 
     - name: Create venv and install
+      if: env.IMAGE_TYPE == 'gcp'
       shell: bash
       run: |
         python -m venv .venv-sbom
@@ -419,7 +422,6 @@ runs:
       run: |
         # Build ${{ inputs.type }} image
         # PACKER_LOG=1
-        sudo systemctl start libvirtd
         sudo sh -c "/usr/bin/packer build ${{ env.PACKER_OPTS }} -only=${{ env.packer_source }} ."
 
     - name: Locate image file, generate checksum
@@ -438,7 +440,67 @@ runs:
         # don't fail if this doesn't exist, we may not always generate it
         sudo mv sbom-data-*.json $(basename ${image_file}).sbom-data.json || true
 
+    - name: Test/check release and architecture, list installed packages in ${{ env.IMAGE_FILE }} cloud image
+      if: ${{ ! contains(inputs.type, 'vagrant') && env.IMAGE_TYPE != 'gcp' }}
+      shell: bash
+      run: |
+        # List installed packages in ${{ env.IMAGE_FILE }} image
+
+        # Partition number with root file-system
+        case ${{ inputs.arch }} in
+          x86_64*) partition=4 ;;
+          aarch64*) partition=3 ;;
+          *) false ;;
+        esac
+
+        # Image file format: raw or qcow2
+        case ${{ inputs.type }} in
+          oci|gencloud|opennebula) format=qcow2 ;;
+          azure) format=raw ;;
+          *) false ;;
+        esac
+        rootfs_path=/mnt/rootfs
+        sudo mkdir -p ${rootfs_path}
+
+        # Install qemu-utils
+        sudo ${{ env.runner_os == 'ubuntu' && 'apt-get' || 'dnf -q' }} \
+          -y install \
+          ${{ env.runner_os == 'ubuntu' && 'qemu-utils' || 'qemu-img' }}
+
+        # Load nbd kernel module
+        sudo modprobe nbd max_part=8
+
+        # Make a copy of the image file
+        sudo cp ${{ env.IMAGE_FILE }} $(dirname ${rootfs_path})
+
+        # Attach the image file to the nbd device
+        sudo qemu-nbd \
+          --read-only \
+          --format=${format} \
+          --connect=/dev/nbd0 \
+          $(dirname ${rootfs_path})/$(basename ${{ env.IMAGE_FILE }}) \
+          && sleep 10 || false
+
+        # Mount need partition
+        sudo fdisk -l /dev/nbd0
+        sudo mount /dev/nbd0p${partition} ${rootfs_path} \
+          && sleep 10 || false
+
+        echo "[Debug] AlmaLinux release:"
+        grep '${{ env.RELEASE_STRING }}' ${rootfs_path}/etc/almalinux-release
+
+        echo "[Debug] System architecture:"
+        rpm --dbpath=${rootfs_path}/var/lib/rpm -q --qf='%{ARCH}\n' ${{ env.RELEASE_PACKAGE }} | grep '${{ env.alma_arch }}'
+
+        # Get installed packages list
+        sudo sh -c "rpm --dbpath=${rootfs_path}/var/lib/rpm -qa --queryformat '%{NAME}\n' | sort > ${{ env.IMAGE_FILE }}.txt"
+
+        [ -f ${{ env.IMAGE_FILE }}.txt ] \
+          && echo "got_pkgs_list=true" >> $GITHUB_ENV \
+          || echo "got_pkgs_list=false" >> $GITHUB_ENV
+
     - name: Generate SBOM
+      if: env.IMAGE_TYPE == 'gcp'
       shell: bash
       run: |
         echo "Generating SBOM document of ${{ env.IMAGE_FILE }}"
@@ -610,7 +672,7 @@ runs:
     - uses: actions/upload-artifact@v4
       name: Store collected sbom data as artifact
       id: sbom-data-artifact
-      if: inputs.store_as_artifact == 'true'
+      if: inputs.store_as_artifact == 'true' && env.IMAGE_TYPE == 'gcp'
       with:
         compression-level: 9
         name: ${{ env.IMAGE_NAME }}.sbom-data.json
@@ -619,7 +681,7 @@ runs:
     - uses: actions/upload-artifact@v4
       name: Store SBOM as artifact
       id: sbom-artifact
-      if: inputs.store_as_artifact == 'true'
+      if: inputs.store_as_artifact == 'true' && env.IMAGE_TYPE == 'gcp'
       with:
         compression-level: 9
         name: ${{ env.IMAGE_NAME }}.sbom.spdx.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,14 +146,6 @@ jobs:
               VARIANTS_SH+=("vagrant_vmware-x86_64") # VMware has networking issues on GitHub runners, so we use self-hosted runner
           fi
 
-          # Add SH values to matrix_gh if using runs-on
-          if [ "${{ github.repository_owner }}" == 'AlmaLinux' ]; then
-            for sh in "${VARIANTS_SH[@]}"; do
-              VARIANTS_GH+=("$sh")
-            done
-            unset VARIANTS_SH
-          fi
-
           [ ${#VARIANTS_GH[@]} -ne 0 ] && matrix_gh=$(printf '"%s",' "${VARIANTS_GH[@]}")
           matrix_gh=${matrix_gh%,}  # Remove the trailing comma
           echo matrix_gh=$(jq -c <<< [${matrix_gh}]) >> $GITHUB_OUTPUT
@@ -188,11 +180,17 @@ jobs:
     needs: [init-data]
     if: ${{ needs.init-data.outputs.matrix_gh != '[]' }}
     # use runs-on runners if within the almalinux org, otherwise GH runners"
-    runs-on: "${{ github.repository_owner == 'AlmaLinux' && format('runs-on={0}/family=c7i.metal-24xl+c7a.metal-48xl+*8gd.metal*/image=ubuntu24-full-{2}', github.run_id, matrix.variant, contains(matrix.matrix_gh, 'aarch64') && 'arm64' || 'x64') || 'ubuntu-24.04' }}"
+    runs-on: >-
+      ${{
+        github.repository_owner == 'AlmaLinux' &&
+          format('runs-on={0}/family=c7i.metal-24xl+c7a.metal-48xl+*8gd.metal*/image=ubuntu24-full-x64', github.run_id)
+        ||
+        'ubuntu-24.04'
+      }}
     strategy:
       fail-fast: false
       matrix:
-        variant: ${{ fromJSON(format('["{0}"]', ( (inputs.version_major == '10-kitten' || inputs.version_major == '10') && !(contains(needs.init-data.outputs.matrix_gh, 'aarch64') ) ) && format('{0}", "{0}-v2', inputs.version_major) || inputs.version_major )) }}
+        variant: ${{ fromJSON(format('["{0}"]', ( inputs.version_major == '10-kitten' || inputs.version_major == '10' ) && format('{0}", "{0}-v2', inputs.version_major) || inputs.version_major )) }}
         matrix_gh: ${{ fromJSON(needs.init-data.outputs.matrix_gh) }}
         exclude:
           - matrix_gh: 'azure-x86_64'
@@ -200,9 +198,6 @@ jobs:
           - matrix_gh: 'oci-x86_64'
             variant: '10-kitten-v2'
           - matrix_gh: 'gcp-x86_64'
-            variant: '10-kitten-v2'
-          # Kitten x86_64_v2 Vagrant for VirtualBox stuck on "Waiting for SSH to become available"
-          - matrix_gh: 'vagrant_virtualbox-x86_64'
             variant: '10-kitten-v2'
           - matrix_gh: 'digitalocean-x86_64'
             variant: '10-kitten-v2'
@@ -245,25 +240,16 @@ jobs:
           store_as_artifact: ${{ inputs.store_as_artifact }}
           upload_to_s3: ${{ inputs.upload_to_s3 }}
           notify_mattermost: ${{ inputs.notify_mattermost }}
-          run_test: true # Do image simple testing and generate installed packages list (vagrant_* and GCP only)
-          # runner: ${{ github.repository_owner == 'AlmaLinux' && 'aws-ec2' || 'gh_hosted' }}
-          runner: gh_hosted
+          run_test: ${{ contains(env.type, 'vagrant') && inputs.run_test && 'true' || 'false' }} # Do image simple testing and generate installed packages list (vagrant_* only)
+          runner: ${{ github.repository_owner == 'AlmaLinux' && 'aws-ec2' || 'gh_hosted' }}
         env:
           PACKER_GITHUB_API_TOKEN: ${{ secrets.GIT_HUB_TOKEN }}
 
-
-
-
-
-
-
-
-### Everything below is for self-hosted runners only ###
-
+  # The job is to start self-hosted runner on AWS EC2 instance if not in the almalinux org
+  # It does nothing if in the almalinux org, so 'Setup and start runner' step is skipped
   start-self-hosted-runner:
     name: ${{ matrix.variant }} ${{ matrix.matrix_sh }} runner
-    # If we're in the almalinux org we use runs-on for self-hosted
-    if: ${{ github.repository_owner != 'AlmaLinux' && inputs.self-hosted && needs.init-data.outputs.matrix_sh != '[]' }}
+    if: ${{ inputs.self-hosted && needs.init-data.outputs.matrix_sh != '[]' }}
     runs-on: ubuntu-24.04
     needs: [init-data]
     strategy:
@@ -321,9 +307,35 @@ jobs:
 
   build-self-hosted:
     name: ${{ matrix.variant }} ${{ matrix.matrix_sh }} image
+    permissions:
+      id-token: write
+      contents: read
     if: ${{ inputs.self-hosted && needs.init-data.outputs.matrix_sh != '[]' }}
     needs: [init-data, start-self-hosted-runner]
-    runs-on: ${{ github.repository_owner == 'AlmaLinux' && ( contains(matrix.matrix_sh, 'x86_64') && format('runs-on={0}/family=c5n.metal/ami={1}', github.run_id, vars.EC2_AMI_ID_AL9_X86_64 ) || format('runs-on={0}/family=a1.metal/image=almalinux-9-aarch64', github.run_id) ) || ( inputs.self_hosted_runner == 'aws-ec2' && github.run_id || matrix.matrix_sh ) }}
+    # If almalinux org, use RunsOn with:
+    # - AlmaLinux 9.x x86_64 specific AWS AMI ID (need to build Vagrant for VMware)
+    # - ubuntu24-full-arm64 for GCP on aarch64
+    #
+    # Otherwise use AWS EC2 Self-Hosted x86_64 or aarch64 runner set up with the 'start-self-hosted-runner' job above
+    #
+    # Or use manually set up runner. Vagrant for VirtualBox x86_64 runner configuration example:
+    # ./config.sh --url https://github.com/almalinux/cloud-images --token ***** --name vagrant_virtualbox-x86_64 --labels vagrant_virtualbox-x86_64 --no-default-labels --work _work --runnergroup default --replace
+    runs-on: >-
+      ${{
+        github.repository_owner == 'AlmaLinux' && (
+          contains(matrix.matrix_sh, 'x86_64') &&
+            format('runs-on={0}/family=c5n.metal/ami={1}', github.run_id, vars.EC2_AMI_ID_AL9_X86_64)
+          ||
+          contains(matrix.matrix_sh, 'gcp') &&
+            format('runs-on={0}/family=c7i.metal-24xl+c7a.metal-48xl+*8gd.metal*/image=ubuntu24-full-arm64', github.run_id)
+          ||
+          format('runs-on={0}/family=a1.metal/image=almalinux-9-aarch64', github.run_id)
+        )
+        ||
+        inputs.self_hosted_runner == 'aws-ec2' && github.run_id
+        ||
+        matrix.matrix_sh
+      }}
     strategy:
       fail-fast: false
       matrix:

--- a/ansible/roles/sbom_data/tasks/main.yml
+++ b/ansible/roles/sbom_data/tasks/main.yml
@@ -1,18 +1,27 @@
 ---
+- name: Check if SBOM data collector exists
+  ansible.builtin.stat:
+    path: "{{ playbook_dir }}/../sbom-tools/sbom_data_collector.py"
+  register: sbom_collector_file
+  delegate_to: localhost
+  become: false
+
 - name: Copy SBOM data collector into the system
   ansible.builtin.copy:
     src: "{{ playbook_dir }}/../sbom-tools/sbom_data_collector.py"
     dest: /dev/shm/sbom_data_collector.py
-  
+  when: sbom_collector_file.stat.exists
+
 - name: Collect SBOM data from the system
   ansible.builtin.shell: python3 /dev/shm/sbom_data_collector.py -o /dev/shm/sbom-data.json -v
   register: sbom_data_collector
   failed_when: false
-  
+  when: sbom_collector_file.stat.exists
+
 - name: Write SBOM data to artifact file
   ansible.builtin.fetch:
     src: /dev/shm/sbom-data.json
     dest: /tmp/sbom-data-{{ packer_build_name }}.json
     flat: true
   become: false
-  when: sbom_data_collector.changed
+  when: sbom_collector_file.stat.exists and sbom_data_collector.changed


### PR DESCRIPTION
- (Put back) an ability to use Self-hosted runners
- (Put back) test/check release and architecture, list installed packages in specific cloud image file
- Generate SBOM data for GCP only
- Add `Check if SBOM data collector exists` task into Ansible `sbom_data` role to prevent SBOM data collection on images except GCP
- Add descriptions of inputs for the shared-steps action