### PR TITLE
chore(docs,aws): amend the documentation of aws_volume_size

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ packer build -only=amazon-ebssurrogate.almalinux_kitten_10_ami_aarch64 .
 
 These input variables can be used for the cutomization of AMIs:
 - Volume type of AMI (default: gp3): `aws_volume_type`
-- Volume size of AMI (default: 4 GiB): `aws_volume_size`
+- Volume size of AMI (default: 5 GiB): `aws_volume_size`
 
 You can also speed-up the build time with upgrading the instance type for builder EC2 Instances:
 - Instance type of x86_64 builder EC2 Instance (default: `t3.small`): `aws_instance_type_x86_64`


### PR DESCRIPTION
Amend the documentation of aws_volume_size to match the change in https://github.com/AlmaLinux/cloud-images/pull/281.

Noticed in https://github.com/AlmaLinux/cloud-images/issues/306.