### PR TITLE
chore(docs): fix README to match the almalinux_9_azure_64k_aarch64 source name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ packer build -only=qemu.almalinux-9-azure-aarch64 .
 `AArch64` with with 64k page size kernel:
 
 ```sh
-packer build -only=qemu.almalinux_9_azure_aarch64_64k .
+packer build -only=qemu.almalinux_9_azure_64k_aarch64 .
 ```
 
 #### AlmaLinux OS Kitten 10


### PR DESCRIPTION
Amend README to match the change in https://github.com/AlmaLinux/cloud-images/pull/244.