### PR TITLE
chore(ci): do not fail on runners which use kvm_intel.

### DIFF
--- a/.github/actions/shared-steps/action.yml
+++ b/.github/actions/shared-steps/action.yml
@@ -319,7 +319,7 @@ runs:
         echo "[Debug] KVM modules:"
         sudo lsmod | grep kvm
         echo "[Debug] Nested virtualization support:"
-        sudo cat /sys/module/kvm_amd/parameters/nested
+        sudo cat /sys/module/kvm_*/parameters/nested
 
     - name: Enable KVM group perms
       if: inputs.type != 'vagrant_virtualbox' && inputs.type != 'vagrant_vmware'


### PR DESCRIPTION
Fixes https://github.com/AlmaLinux/cloud-images/issues/312.

It is quite hard to hit an Intel machine in the GitHub Actions hosted runner pool so I admit I did not see this change work.

But given the code as written does not check if the content of the `/sys/module/kvm_amd/parameters/nested` is `1` or `Y` anyway and on my local `kvm_intel` machine with kernel 6.18.7-200.fc43.x86_64 there is a
```
$ cat /sys/module/kvm_intel/parameters/nested
Y
```
present, this should not decrease the value of that "check" and it could minimize confusion of people who happen to hit `kvm_intel` upon their first attempt.