### PR TITLE
Update documentation: add detailed documentation for each workflow

### DIFF
--- a/AWS_AMI_BUILD_COPY_RELEASE.md
+++ b/AWS_AMI_BUILD_COPY_RELEASE.md
@@ -1,0 +1,264 @@
+# AWS Marketplace Publishing
+
+## Overview
+
+This repository includes GitHub Actions workflows for building, distributing, and publishing AlmaLinux OS AMIs (Amazon Machine Images) to AWS Marketplace. The process is split into three separate workflows that are run sequentially.
+
+## Workflows
+
+### 1. `.github/workflows/build-ami.yml` — Build AMI
+
+Builds AlmaLinux OS AMIs from source using Packer and Ansible.
+
+**What it does:**
+- Builds AMIs for both x86_64 and aarch64 architectures in parallel
+- Uses EBS Surrogate build strategy with Packer
+- Finds the latest existing AlmaLinux AMI as the source/base image
+- Grants launch permission to the AlmaLinux infrastructure account
+- Optionally tests the built AMIs by launching instances from them
+- Sends Mattermost notifications and generates job summaries
+
+**Usage:**
+```
+Trigger via GitHub UI: Actions → AWS AMI Build
+
+Inputs:
+  - version_major:    AlmaLinux major version (choice: kitten_10, 10, 9, 8)
+  - test_ami:         Test built AMI (default: true)
+  - notify_mattermost: Send notification to Mattermost (default: true)
+```
+
+### 2. `.github/workflows/copy-ami.yml` — Copy AMI to Regions
+
+Copies built AMIs to all available AWS regions and makes them public.
+
+**What it does:**
+- Takes x86_64 and aarch64 AMI IDs as input
+- Copies each AMI to all available AWS regions using `tools/aws_ami_mirror.py`
+- Makes the copied AMIs public in all regions
+- Generates CSV and Markdown tables of AMI IDs per region
+- Creates a Pull Request to the AlmaLinux Wiki (`almalinux/wiki`) with updated AMI tables
+- Sends Mattermost notifications and generates job summaries
+
+**Usage:**
+```
+Trigger via GitHub UI: Actions → AWS AMI copy to Regions, make Public
+
+Inputs:
+  - x86_64_ami_id:    AMI ID for x86_64 (required)
+  - aarch64_ami_id:   AMI ID for aarch64 (required)
+  - make_public:      Copy to all regions and make public (default: true)
+  - draft:            Create Wiki PR as draft (default: true)
+  - notify_mattermost: Send notification to Mattermost (default: true)
+```
+
+### 3. `.github/workflows/ami-to-marketplace.yml` — Publish to Marketplace
+
+Releases an AMI to the corresponding AWS Marketplace product.
+
+**What it does:**
+- Takes a single AMI ID as input
+- Describes the AMI to extract version, architecture, and OS information
+- Maps the AMI to the corresponding AWS Marketplace product ID
+- Renders a Marketplace change set from a JSON template
+- Submits the change set via `aws marketplace-catalog start-change-set`
+- Supports a test mode using a non-public dev product
+- Sends Mattermost notifications and generates job summaries
+
+**Usage:**
+```
+Trigger via GitHub UI: Actions → AWS AMI to Marketplace release
+
+Inputs:
+  - ami_id:                AMI ID to release (required)
+  - release_to_marketplace: Submit to Marketplace (default: true)
+  - public_product:        Use public product ID (default: false)
+  - notify_mattermost:     Send notification to Mattermost (default: false)
+```
+
+**Note:** The marketplace workflow processes one AMI at a time. To publish both architectures, run it twice — once for x86_64 and once for aarch64.
+
+## Required GitHub Configuration
+
+### Secrets
+| Secret | Description |
+|--------|-------------|
+| `AWS_ACCESS_KEY_ID` | AWS access key ID |
+| `AWS_SECRET_ACCESS_KEY` | AWS secret access key |
+| `GIT_HUB_TOKEN` | GitHub PAT with repo access (used for Packer plugins and Wiki PRs) |
+| `MATTERMOST_WEBHOOK_URL` | Mattermost incoming webhook URL |
+
+### Variables (`vars.*`)
+| Variable | Description |
+|----------|-------------|
+| `AWS_REGION` | Primary AWS region for builds and API calls |
+| `MATTERMOST_CHANNEL` | Mattermost channel for notifications |
+
+## Prerequisites
+
+1. **AWS IAM Credentials**
+   - The AWS credentials must have permissions for:
+     - **EC2**: `describe-images`, `copy-image`, `modify-image-attribute`, `create-image` (for Packer builds)
+     - **Marketplace Catalog**: `describe-entity`, `start-change-set`
+   - A separate IAM role (`alma-images-marketplace-role`) is used for Marketplace AMI access
+
+2. **Packer Templates**
+   - Packer templates must exist in the repository root matching the naming convention:
+     `amazon-ebssurrogate.almalinux_{variant}_ami_{arch}`
+   - Packer is installed from the HashiCorp APT repository during the build
+
+3. **Source AMIs**
+   - The build workflow automatically finds the latest existing AlmaLinux AMI (owned by account `764336703387`) as the source image
+
+4. **AlmaLinux Wiki Repository**
+   - The copy workflow creates PRs against `almalinux/wiki` with updated AMI tables
+   - Requires `GIT_HUB_TOKEN` with write access to that repository
+
+5. **AWS Marketplace Products**
+   - Products must already exist in AWS Marketplace
+   - Product IDs are hardcoded in the marketplace workflow (see [Product ID Mapping](#product-id-mapping))
+
+## Supported Products
+
+### Product ID Mapping
+
+| Product | Architecture | Product ID |
+|---------|-------------|------------|
+| AlmaLinux OS 8 | x86_64 | `c076b20a-2305-4771-823f-944909847a05` |
+| AlmaLinux OS 8 | arm64 | `744775f7-4efd-4c75-ac32-eb2540b4030c` |
+| AlmaLinux OS 9 | x86_64 | `3c74c2ba-21a2-4dc1-a65d-fd0ee7d79900` |
+| AlmaLinux OS 9 | arm64 | `2d219cc1-aa44-4a1e-b6fe-258d4ebd3cdb` |
+| AlmaLinux OS 10 | x86_64 | `prod-cvyxsvsdzfjx4` |
+| AlmaLinux OS 10 | arm64 | `prod-qgpr5bqxuzt5i` |
+| AlmaLinux OS Kitten 10 | x86_64 | `prod-svbminwb7w5se` |
+| AlmaLinux OS Kitten 10 | arm64 | `prod-npz256ulofnae` |
+| (Dev/Test) | any | `prod-t4oyq2p42jn2u` |
+
+The dev/test product is used when `public_product` is set to `false`.
+
+## End-to-End Process
+
+### Typical Release Flow
+
+```mermaid
+graph TD
+    A[1. Run build-ami workflow] --> B[Builds x86_64 + aarch64 AMIs]
+    B --> C[Optional: Test AMIs]
+    C --> D[2. Run copy-ami workflow]
+    D --> E[Copy AMIs to all AWS regions]
+    E --> F[Make AMIs public]
+    F --> G[Generate Wiki AMI tables]
+    G --> H[Create PR to almalinux/wiki]
+    H --> I[3. Run ami-to-marketplace workflow x2]
+    I --> J[Submit x86_64 AMI to Marketplace]
+    I --> K[Submit aarch64 AMI to Marketplace]
+    J --> L[AWS reviews and publishes]
+    K --> L
+```
+
+### Step 1: Build AMIs (`build-ami`)
+
+1. Checks out the repository
+2. Configures AWS credentials
+3. Finds the latest AlmaLinux source AMI for the target version and architecture
+4. Installs Packer and Ansible
+5. Runs the Packer EBS Surrogate build template
+6. Extracts the new AMI ID from the build log
+7. Grants launch permission to the infrastructure account (`383541928683`)
+8. Optionally tests the AMI by launching an instance (using [runs-on](https://runs-on.com/) self-hosted runners)
+
+The test step:
+- Launches an instance from the built AMI
+- Verifies the OS release string matches
+- Verifies the architecture matches
+- Runs `dnf check-update` to confirm repo access
+- Captures the installed package list as a build artifact
+
+### Step 2: Copy to Regions (`copy-ami`)
+
+1. Copies each AMI to all available AWS regions using `tools/aws_ami_mirror.py`
+2. Makes all copied AMIs public
+3. Generates per-region AMI ID tables in CSV and Markdown formats
+4. Merges x86_64 and aarch64 tables, sorted by region
+5. Commits the data to a new branch in the `almalinux/wiki` repository
+6. Creates a Pull Request (optionally as draft) to update the Wiki
+
+### Step 3: Publish to Marketplace (`ami-to-marketplace`)
+
+1. Describes the AMI to extract metadata (version, architecture, name)
+2. Determines the OS version and maps to the correct Marketplace product ID
+3. Fetches the recommended instance type from the existing product (falls back to `t3.small`/`t4g.small`)
+4. Renders a change set from `.github/aws_marketplace_change_set.json.template`
+5. Submits the change set to AWS Marketplace Catalog API
+6. AWS reviews and publishes the new version
+
+### Marketplace Change Set
+
+The change set template (`.github/aws_marketplace_change_set.json.template`) uses the `AddDeliveryOptions` change type with these parameters:
+
+| Parameter | Value |
+|-----------|-------|
+| Version Title | AMI version string (e.g., `9.6.20250522`) |
+| OS Name | `OTHERLINUX` |
+| Username | `ec2-user` |
+| Security Group | TCP/22 (SSH) from `0.0.0.0/0` |
+| Recommended Instance Type | From existing product or `t3.small`/`t4g.small` |
+
+## Helper Tools
+
+### `tools/aws_ami_mirror.py`
+
+Python script that copies an AMI to all available AWS regions and makes it public.
+
+**Dependencies:** `boto3`, `markdown_table` (installed via `pip3` during the workflow)
+
+**What it does:**
+- Takes a source AMI ID
+- Copies the AMI to every available AWS region concurrently
+- Waits for all copies to become available
+- Makes each copy public
+- Generates Markdown and CSV files with per-region AMI IDs
+
+## Manual Steps
+
+1. **After `build-ami`**: Note the AMI IDs from the job output or Mattermost notification to use as input for the next workflow
+2. **After `copy-ami`**: Review and merge the Wiki PR created in `almalinux/wiki`
+3. **After `ami-to-marketplace`**: Monitor the change set status in the [AWS Marketplace Management Portal](https://aws.amazon.com/marketplace/management/requests/) — AWS reviews and publishes automatically
+
+## Troubleshooting
+
+### Common Issues
+
+1. **"Failed to get AMI ID" during build**
+   - The source AMI lookup failed — ensure AlmaLinux AMIs exist in the primary region owned by account `764336703387`
+   - Check the `version_major` input matches an existing AMI name pattern
+
+2. **Build fails with Packer errors**
+   - Check the uploaded build log artifact for details
+   - Ensure the Packer template exists for the selected variant and architecture
+   - Verify AWS credentials have EC2 permissions
+
+3. **AMI copy fails or times out**
+   - `aws_ami_mirror.py` copies to all regions concurrently
+   - Some regions may be slow; the script handles retries internally
+   - Check if the source AMI is in `available` state
+
+4. **Wiki PR creation fails**
+   - Ensure `GIT_HUB_TOKEN` has write access to `almalinux/wiki`
+   - A branch with the same name may already exist from a previous run
+
+5. **"Unsupported AlmaLinux release" in marketplace workflow**
+   - The AMI name/version/architecture combination doesn't match any known product
+   - Update the product ID mapping in the workflow if a new product was created
+
+6. **Marketplace change set fails**
+   - Check the change set status in the AWS Marketplace Management Portal
+   - Ensure the AMI is in `available` state and publicly accessible
+   - Verify the IAM role ARN (`alma-images-marketplace-role`) is correctly configured
+
+## Support
+
+- AWS Marketplace Management Portal: https://aws.amazon.com/marketplace/management/
+- AlmaLinux Wiki: https://wiki.almalinux.org
+- AlmaLinux Cloud SIG Chat: https://chat.almalinux.org/almalinux/channels/sigcloud
+- Workflow run logs: GitHub Actions tab in the repository

--- a/AZURE_GALLERY.md
+++ b/AZURE_GALLERY.md
@@ -1,0 +1,277 @@
+# Azure Community Gallery Publishing
+
+## Overview
+
+This repository includes a GitHub Actions workflow and a helper script for publishing AlmaLinux OS images to Azure Compute Galleries (formerly Shared Image Galleries).
+
+## Files
+
+### `.github/workflows/azure-to-gallery.yml`
+
+Workflow for releasing AlmaLinux OS images to an Azure Compute Gallery.
+
+**What it does:**
+- Accepts either a RAW image URL (from AWS S3) or an already-uploaded VHD blob URL
+- Parses the image filename to extract version, timestamp, and architecture
+- If RAW: downloads the image, converts it to fixed VHD via `qemu-img`, and uploads to Azure Blob Storage
+- If VHD: uses the provided blob URL directly
+- Creates image definition versions in the Azure Compute Gallery, replicated across multiple regions
+- Supports dry-run mode for testing without making changes
+- Supports both a CI (private) gallery and a public gallery
+- Sends Mattermost notifications and generates job summaries
+
+**Usage:**
+```
+Trigger via GitHub UI: Actions → Azure image to Gallery release
+
+Inputs:
+  - url_type:          Image format (choice: "RAW at AWS S3", "VHD blob at Azure")
+  - image_url:         The image URL (required)
+  - dry-run-mode:      Dry-run mode (default: true)
+  - public_gallery:    Release to public Gallery (default: false)
+  - notify_mattermost: Send notification to Mattermost (default: false)
+```
+
+### `tools/azure_uploader.sh`
+
+Bash script that handles the actual image conversion, upload, and gallery operations.
+
+**Dependencies:** `azure-cli`, `qemu-img`, `jq`
+
+**What it does:**
+- Converts RAW images to fixed-size VHD format (rounded to 1 MB boundary)
+- Uploads VHD blobs to Azure Storage with MD5 validation
+- Creates image definition versions in the Compute Gallery
+- For x86_64 images: creates both Gen1 and Gen2 image definition versions
+- For ARM images: creates Gen2 image definition version only
+- Supports dry-run mode (default) — pass `-f` to execute actual operations
+- Calculates unique image indices to avoid naming collisions
+- Replicates images to multiple target regions
+
+**Usage:**
+```bash
+# Dry-run (default): shows what would be executed
+./azure_uploader.sh -d 9.6 -t default -i AlmaLinux-9-Azure-9.6.raw
+
+# Actual upload from RAW image
+./azure_uploader.sh -d 9.6 -t default -i AlmaLinux-9-Azure-9.6.raw -f
+
+# Upload from existing VHD blob URL
+./azure_uploader.sh -d 9.6 -t default -u https://almalinux.blob.core.windows.net/... -f
+
+# Upload to public gallery
+./azure_uploader.sh -d 9.6 -t default -i AlmaLinux-9-Azure-9.6.raw -f -g almalinux
+```
+
+## Required GitHub Configuration
+
+### Secrets
+| Secret | Description |
+|--------|-------------|
+| `AZURE_CLIENT_ID` | Azure service principal client ID |
+| `AZURE_TENANT_ID` | Azure tenant ID |
+| `AZURE_SUBSCRIPTION_ID` | Azure subscription ID |
+| `MATTERMOST_WEBHOOK_URL` | Mattermost incoming webhook URL |
+
+### Variables (`vars.*`)
+| Variable | Description |
+|----------|-------------|
+| `MATTERMOST_CHANNEL` | Mattermost channel for notifications |
+
+### GitHub Permissions
+The workflow requires:
+- `id-token: write` — for Azure OIDC authentication
+- `contents: read` — for repository checkout
+
+## Prerequisites
+
+1. **Azure Service Principal**
+   - Must be configured for OIDC (federated credentials) authentication with GitHub Actions
+   - Requires permissions to:
+     - Upload blobs to the Azure Storage account
+     - Create/manage image definition versions in the Compute Gallery
+
+2. **Azure Storage Account**
+   - Default storage account: `almalinux`
+   - Contains per-version/type storage containers (e.g., `8-default`, `9-arm64`, `almalinux-10`, `kitten-10`)
+
+3. **Azure Compute Galleries**
+   - CI/private gallery: `almalinux_ci` (default)
+   - Public gallery: `almalinux` (used when `public_gallery` is `true`)
+   - Resource group: `rg-alma-images`
+
+4. **Image Definitions**
+   - Image definitions must already exist in the gallery for each version/architecture/generation combination
+   - The script generates definition names automatically (see [Image Definition Naming](#image-definition-naming))
+
+## Supported Image Types
+
+| Image Type | Architecture | VM Generations | Description |
+|------------|-------------|----------------|-------------|
+| `default` | x86_64 | Gen1 + Gen2 | Standard x86_64 images |
+| `arm64` | aarch64/arm64 | Gen2 only | Standard ARM64 images |
+| `arm64-64k` | aarch64 | Gen2 only | ARM64 with 64K page size (AlmaLinux 9+) |
+
+## Image Filename Patterns
+
+The workflow parses filenames to extract metadata. Two input formats are supported:
+
+### RAW Images (from AWS S3)
+```
+AlmaLinux-{major}-Azure-{version}-{date}.{index}.{arch}.raw
+```
+Example: `AlmaLinux-10-Azure-10.0-20250529.0.x86_64.raw`
+
+### VHD Images (Modern format)
+```
+AlmaLinux-{major}-Azure-{version}-{date}.{index}[-64k].{arch}.vhd
+```
+Example: `AlmaLinux-10-Azure-10.0-20250529.0-64k.aarch64.vhd`
+
+### VHD Images (Legacy format)
+```
+almalinux-{version}-{arch}.{date}-{index}.vhd
+```
+Example: `almalinux-9.6-arm64.20250522-01.vhd`
+
+### Extracted Metadata
+- `RELEASE_VERSION` — distribution version (e.g., `9.6`, `10.0`, `10`)
+- `TIMESTAMP` — date with optional index (e.g., `20250529.0`)
+- `IMAGE_TYPE` — `default`, `arm64`, or `arm64-64k` (derived from architecture and 64K page size flag)
+
+## Image Definition Naming
+
+The script generates Azure Compute Gallery image definition names following these patterns:
+
+| Version | Type | Generation | Definition Name |
+|---------|------|------------|-----------------|
+| 8.x | default | Gen1 | `almalinux-8-gen1` |
+| 8.x | default | Gen2 | `almalinux-8-gen2` |
+| 8.x | arm64 | Gen2 | `almalinux-8-arm64` |
+| 9.x | default | Gen1 | `almalinux-9-gen1` |
+| 9.x | default | Gen2 | `almalinux-9-gen2` |
+| 9.x | arm64 | Gen2 | `almalinux-9-arm64` |
+| 9.x | arm64-64k | Gen2 | `almalinux-9-arm64-64k` |
+| 10.x | default | Gen1/2 | `almalinux-10-gen1`/`almalinux-10-gen2` (proposed) |
+| 10.x | arm64 | Gen2 | `almalinux-ci-10-arm64-gen2` |
+| 10.x | arm64-64k | Gen2 | `almalinux-ci-10-arm64-64k-gen2` |
+| Kitten 10 | default | Gen1 | `almalinux-ci-kitten-10-x64-gen1` |
+| Kitten 10 | default | Gen2 | `almalinux-ci-kitten-10-x64-gen2` |
+| Kitten 10 | arm64 | Gen2 | `almalinux-ci-kitten-10-arm64-gen2` |
+
+## Storage Container Naming
+
+Blob containers are named per major version and image type:
+
+| Version | Type | Container Name |
+|---------|------|---------------|
+| 8.x | default | `8-default` |
+| 8.x | arm64 | `8-arm64` |
+| 9.x | default | `9-default` |
+| 9.x | arm64 | `9-arm64` |
+| 9.x | arm64-64k | `9-arm64-64k` |
+| 10.x | any | `almalinux-10` |
+| Kitten 10 | any | `kitten-10` |
+
+## Workflow Process
+
+```mermaid
+graph TD
+    A[Trigger Workflow] --> B[Parse Image Filename]
+    B --> C{Input Type?}
+    C -->|RAW at AWS S3| D[Download RAW Image]
+    D --> E[Convert RAW → Fixed VHD]
+    E --> F[Upload VHD to Blob Storage]
+    F --> G[Get Blob URI]
+    C -->|VHD blob at Azure| G
+    G --> H{Architecture?}
+    H -->|x86_64| I[Create Gen1 + Gen2 Image Versions]
+    H -->|ARM64| J[Create Gen2 Image Version]
+    I --> K{Dry-Run?}
+    J --> K
+    K -->|No| L[Images Replicated to Target Regions]
+    K -->|Yes| M[Dry-Run Complete]
+    L --> N[Generate Summary & Notify]
+    M --> N
+```
+
+### RAW Image Processing (full flow)
+
+1. Downloads the RAW image from AWS S3 to `/mnt` (which has ~70 GB of disk space)
+2. Rounds the image size up to the nearest 1 MB boundary
+3. Resizes the RAW image if needed using `qemu-img resize`
+4. Converts RAW to fixed VHD format using `qemu-img convert`
+5. Calculates the MD5 checksum of the VHD blob
+6. Uploads the VHD blob to Azure Blob Storage with MD5 validation
+7. Creates image definition version(s) in the gallery from the blob URI
+
+### VHD Blob Processing (shortened flow)
+
+1. Uses the provided VHD blob URL directly
+2. Creates image definition version(s) in the gallery from the existing blob URI
+
+### Target Regions
+
+Images are replicated to the following Azure regions (with 1 replica each):
+
+- `eastus`
+- `germanywestcentral`
+- `westus2`
+- `southeastasia`
+- `southcentralus`
+
+## Testing
+
+1. **Dry-Run Mode** (default)
+   - Set `dry-run-mode: true` (default)
+   - The script shows all commands that would be executed without making any changes
+   - Useful for verifying filename parsing and parameter generation
+
+2. **CI Gallery Release**
+   - Set `dry-run-mode: false`, `public_gallery: false`
+   - Uploads to the `almalinux_ci` private gallery
+   - Verify the image definition version in the Azure Portal
+
+3. **Public Gallery Release**
+   - Set `dry-run-mode: false`, `public_gallery: true`
+   - Uploads to the `almalinux` public gallery
+
+## Troubleshooting
+
+### Common Issues
+
+1. **"Could not parse filename" error**
+   - Ensure the image filename matches one of the supported patterns (RAW or VHD)
+   - Check for unexpected characters or missing version/date components
+
+2. **Image download fails**
+   - Verify the RAW image URL is publicly accessible
+   - The download goes to `/mnt` which has ~70 GB of space on GitHub runners — ensure the image fits
+
+3. **VHD conversion fails**
+   - Ensure `qemu-utils` is installed (the workflow installs it automatically)
+   - Check that the RAW image is a valid disk image
+
+4. **Azure login fails**
+   - Verify `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_SUBSCRIPTION_ID` secrets are correct
+   - Ensure the service principal has OIDC federated credentials configured for the GitHub repository
+
+5. **Blob upload fails**
+   - Check that the storage container exists for the version/type combination
+   - Verify the service principal has `Storage Blob Data Contributor` role on the storage account
+
+6. **Image definition version creation fails**
+   - Ensure the image definition already exists in the gallery
+   - Check that the version number doesn't already exist (use dry-run to preview)
+   - Verify the service principal has `Contributor` role on the gallery resource group
+
+7. **Image with same name already exists**
+   - The script auto-increments an index to generate unique blob names
+   - If collisions still occur, check existing blobs in the storage container
+
+## Support
+
+- Azure Portal: https://portal.azure.com
+- Azure Compute Gallery docs: https://learn.microsoft.com/en-us/azure/virtual-machines/azure-compute-gallery
+- AlmaLinux Cloud SIG Chat: https://chat.almalinux.org/almalinux/channels/sigcloud
+- Workflow run logs: GitHub Actions tab in the repository

--- a/BUILD_CLOUD_IMAGES.md
+++ b/BUILD_CLOUD_IMAGES.md
@@ -1,0 +1,279 @@
+# Build Cloud and Vagrant Images
+
+## Overview
+
+This repository includes a GitHub Actions workflow and a reusable composite action for building AlmaLinux OS cloud and Vagrant images using Packer. This is the primary build pipeline that produces images for all supported cloud platforms and hypervisors.
+
+## Files
+
+### `.github/workflows/build.yml`
+
+Main workflow that orchestrates image builds across multiple platforms, architectures, and variants.
+
+**What it does:**
+- Builds cloud images (Azure, GCP, GenCloud, OCI, OpenNebula, Hyper-V) and Vagrant boxes (libvirt, VirtualBox, VMware)
+- Supports AlmaLinux 8, 9, 10, and Kitten 10
+- Builds for both x86_64 and aarch64 architectures, plus x86_64_v2 and aarch64 64K page variants
+- Splits work between GitHub-hosted runners (x86_64) and self-hosted runners (aarch64, VMware)
+- Generates SHA-256 checksums for all images
+- Optionally stores images as GitHub Actions artifacts
+- Optionally uploads images to AWS S3 with public tagging
+- Optionally runs image tests
+- Sends Mattermost notifications
+
+**Usage:**
+```
+Trigger via GitHub UI: Actions → Build Cloud and Vagrant Images
+
+Inputs:
+  - date_time_stamp:    Custom timestamp YYYYMMDDhhmmss (auto-generated if empty)
+  - version_major:      AlmaLinux version (choice: 10-kitten, 10, 9, 8)
+  - image_type:         Cloud image type (NONE, ALL, azure, gcp, gencloud, hyperv, oci, opennebula)
+  - vagrant_type:       Vagrant image type (NONE, ALL, vagrant_libvirt, vagrant_virtualbox, vagrant_vmware)
+  - self-hosted:        Allow self-hosted runners (default: true)
+  - self_hosted_runner: Self-hosted runner type (self-hosted, aws-ec2)
+  - run_test:           Test built images - vagrant only (default: true)
+  - store_as_artifact:  Store images as GitHub artifacts (default: false)
+  - upload_to_s3:       Upload to S3 bucket (default: true)
+  - notify_mattermost:  Send notifications (default: false)
+```
+
+### `.github/actions/shared-steps/action.yml`
+
+Reusable composite action containing the actual build, test, upload, and notification logic.
+
+**What it does:**
+- Detects the runner OS (Ubuntu or RHEL) and installs appropriate packages
+- Installs KVM, Packer, and Ansible
+- Configures virtualization (KVM, VirtualBox, or VMware depending on image type)
+- Runs Packer to build the image
+- Locates the output image and generates SHA-256 checksum
+- Tests the image (mounts qcow2/raw for cloud images, or runs `vagrant up` for Vagrant boxes)
+- Generates SBOM (Software Bill of Materials) for GCP images
+- Uploads images and artifacts to S3 and/or GCP storage
+- Generates job summaries and Mattermost notifications
+
+## Required GitHub Configuration
+
+### Secrets
+| Secret | Description |
+|--------|-------------|
+| `AWS_ACCESS_KEY_ID` | AWS access key for S3 uploads |
+| `AWS_SECRET_ACCESS_KEY` | AWS secret key for S3 uploads |
+| `GIT_HUB_TOKEN` | GitHub PAT (used for Packer plugins and self-hosted runner provisioning) |
+| `MATTERMOST_WEBHOOK_URL` | Mattermost incoming webhook URL |
+| `EC2_AMI_ID_AL9_X86_64` | AMI ID for x86_64 self-hosted EC2 runner |
+| `EC2_AMI_ID_AL9_AARCH64` | AMI ID for aarch64 self-hosted EC2 runner |
+| `EC2_SUBNET_ID` | EC2 subnet for self-hosted runners |
+| `EC2_SECURITY_GROUP_ID` | EC2 security group for self-hosted runners |
+
+### Variables (`vars.*`)
+| Variable | Description |
+|----------|-------------|
+| `AWS_REGION` | AWS region for S3 and EC2 |
+| `AWS_S3_BUCKET` | S3 bucket name for storing built images |
+| `MATTERMOST_CHANNEL` | Mattermost channel for notifications |
+| `EC2_AMI_ID_AL9_X86_64` | AMI ID for RunsOn x86_64 runners (AlmaLinux org only) |
+
+### Permissions
+The workflow requires:
+- `id-token: write` — for GCP Workload Identity Federation and Azure OIDC
+- `contents: read` — for repository checkout
+
+## Supported Image Types
+
+### Cloud Images
+
+| Type | Output Format | Architectures | Notes |
+|------|--------------|---------------|-------|
+| `azure` | `.raw` | x86_64, aarch64, aarch64-64k | Azure VHD source; 64K page variant for AL9+ |
+| `gcp` | `.tar.gz` | x86_64, aarch64 | Google Cloud; includes SBOM generation |
+| `gencloud` | `.qcow2` | x86_64, aarch64 | Generic cloud (OpenStack, etc.) |
+| `hyperv` | `.box` | x86_64 only | Hyper-V Vagrant box; built with QEMU |
+| `oci` | `.qcow2` | x86_64, aarch64 | Oracle Cloud Infrastructure |
+| `opennebula` | `.qcow2` | x86_64, aarch64 | OpenNebula platform |
+
+### Vagrant Boxes
+
+| Type | Provider | Architectures | Runner |
+|------|----------|---------------|--------|
+| `vagrant_libvirt` | libvirt (KVM/QEMU) | x86_64 | GitHub-hosted |
+| `vagrant_virtualbox` | VirtualBox | x86_64 | GitHub-hosted |
+| `vagrant_vmware` | VMware Desktop | x86_64 | Self-hosted (networking issues on GH runners) |
+
+### Version Variants
+
+| Input | Variants Built | Notes |
+|-------|---------------|-------|
+| `8` | `8` | Single variant |
+| `9` | `9` | Single variant; Azure also builds `9-64k` on aarch64 |
+| `10` | `10`, `10-v2` | v2 = x86_64_v2 microarchitecture; Azure also builds `10-64k` |
+| `10-kitten` | `10-kitten`, `10-kitten-v2` | Kitten builds; Azure also builds `10-kitten-64k` |
+
+The `-v2` suffix produces images with x86_64_v2 microarchitecture level support. The `-64k` suffix produces aarch64 images with 64K page size (Azure only, AL9+).
+
+## Build Matrix
+
+The workflow splits builds into two runner groups:
+
+### GitHub-Hosted (`build-gh-hosted`)
+
+Runs on GitHub-hosted or [RunsOn](https://runs-on.com/) metal instances (when in the AlmaLinux org).
+
+Builds: all x86_64 cloud images, Vagrant libvirt, Vagrant VirtualBox
+
+### Self-Hosted (`build-self-hosted`)
+
+Runs on self-hosted EC2 instances (via `ec2-action-builder`) or RunsOn ARM instances.
+
+Builds: all aarch64 cloud images, Vagrant VMware (x86_64)
+
+### Matrix Exclusions
+
+Certain variant/type combinations are excluded:
+- **v2 variants**: excluded from Azure, OCI, GCP, DigitalOcean (cloud images don't use v2)
+- **64k variants**: excluded from OCI, GenCloud, OpenNebula (only Azure supports 64K page)
+- **OCI**: excluded for Kitten (aarch64)
+
+## Workflow Process
+
+```mermaid
+graph TD
+    A[Trigger Workflow] --> B[Initialize: Generate Timestamp, Build Matrix]
+    B --> C{Has GH-hosted builds?}
+    B --> D{Has Self-hosted builds?}
+    C -->|Yes| E[build-gh-hosted jobs]
+    D -->|Yes| F[Start self-hosted runners]
+    F --> G[build-self-hosted jobs]
+    E --> H[Shared Steps]
+    G --> H
+    H --> I[Install KVM/VBox/VMware + Packer + Ansible]
+    I --> J[Run Packer Build]
+    J --> K[Locate Image + Generate Checksum]
+    K --> L{Image Type?}
+    L -->|Cloud| M[Mount & Test Image via NBD]
+    L -->|Vagrant| N[vagrant up & Test via SSH]
+    L -->|GCP| O[Generate SBOM + Upload to GCS]
+    M --> P[Extract Package List]
+    N --> P
+    P --> Q{Upload to S3?}
+    Q -->|Yes| R[Upload Image + Checksum + Pkg List to S3]
+    Q -->|No| S{Store as Artifact?}
+    S -->|Yes| T[Upload to GitHub Artifacts]
+    R --> U[Generate Summary + Notify]
+    T --> U
+```
+
+## S3 Upload Structure
+
+Built images are uploaded to S3 with the following path structure:
+
+```
+s3://{bucket}/images/{version_major}/{release}/{type}/{timestamp}/
+```
+
+Examples:
+```
+s3://almalinux-cloud/images/9/9.6/azure/20260220143000/AlmaLinux-9-Azure-9.6-20260220.x86_64.raw
+s3://almalinux-cloud/images/9/9.6/vagrant/20260220143000/AlmaLinux-9-Vagrant-libvirt-9.6-20260220.0.x86_64.box
+s3://almalinux-cloud/images/kitten/10/azure/20260220143000/AlmaLinux-Kitten-Azure-10-20260220.0.x86_64.raw
+```
+
+All uploaded objects are tagged with `public=yes`.
+
+## Image Testing
+
+### Cloud Image Testing
+
+For cloud images (not GCP, not Vagrant), the shared action:
+1. Loads the `nbd` kernel module
+2. Attaches the image using `qemu-nbd` (read-only)
+3. Mounts the root partition (partition 4 for x86_64, partition 3 for aarch64)
+4. Verifies `/etc/almalinux-release` matches the expected release string
+5. Verifies the architecture of the `almalinux-release` package
+6. Extracts the list of installed RPM packages
+
+### Vagrant Image Testing
+
+For Vagrant boxes (when `run_test` is enabled):
+1. Installs Vagrant and the appropriate provider plugin
+2. Adds the built box locally
+3. Creates a Vagrantfile with 2 CPUs and 2 GB RAM
+4. Runs `vagrant up` with the correct provider
+5. Verifies `/etc/almalinux-release` via SSH
+6. Verifies architecture via SSH
+7. Runs `dnf check-update` to confirm repository access
+8. Extracts installed package list via SSH
+9. Cleans up the VM and box
+
+### GCP-Specific Steps
+
+For GCP images, additional steps are performed:
+1. Generates SBOM (Software Bill of Materials) using `cloud-images-sbom-tools`
+2. Uploads the image tarball to a GCS bucket
+3. Uploads the SBOM to a separate GCS bucket
+4. Builds the `gce_image_publish` tool from `GoogleCloudPlatform/compute-image-tools`
+5. Creates a test image in the GCP project
+
+## Packer Configuration
+
+The shared action constructs Packer source names and options dynamically based on the image type and variant. The general pattern is:
+
+```
+{builder}.almalinux-{version}-{type}-{arch}      (AL 8/9)
+{builder}.almalinux_{version}_{type}_{arch}       (AL 10/Kitten)
+```
+
+Where `{builder}` is `qemu`, `virtualbox-iso`, or `vmware-iso`.
+
+### Packer Options by Runner OS
+
+| Runner OS | QEMU Binary | OVMF Firmware |
+|-----------|-------------|---------------|
+| Ubuntu | `/usr/bin/qemu-system-{arch}` | `/usr/share/OVMF/OVMF_CODE_4M.fd` |
+| RHEL | `/usr/libexec/qemu-kvm` | (default) |
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Packer build fails**
+   - Check the Packer template exists for the variant/type/arch combination
+   - Ensure the runner has enough disk space and RAM
+   - For QEMU builds, verify KVM is available (`/dev/kvm` exists and is accessible)
+
+2. **KVM permissions error**
+   - The workflow configures udev rules for KVM access
+   - On self-hosted runners, ensure the runner user is in the `kvm` group
+
+3. **VirtualBox or VMware build fails**
+   - VirtualBox and VMware require KVM to be unloaded (they provide their own hypervisor)
+   - VMware requires a specific bundle version and license configuration
+
+4. **Image test fails (cloud)**
+   - Ensure `nbd` kernel module is available
+   - Check that the root partition number is correct for the architecture
+
+5. **Vagrant test fails**
+   - `vagrant up` may fail with SSH connection issues (known issue with libvirt)
+   - VirtualBox tests may not work on standard GitHub runners (use self-hosted)
+   - VMware requires the `vagrant-vmware-utility` service running
+
+6. **S3 upload fails**
+   - Verify AWS credentials have S3 write permissions
+   - Check the bucket name and region are correct
+
+7. **GCP-related steps fail**
+   - Verify Workload Identity Federation is configured for the repository
+   - Check the GCS bucket permissions
+
+8. **Self-hosted runner doesn't start**
+   - Verify EC2 AMI IDs, subnet, and security group secrets
+   - Check AWS credentials have EC2 launch permissions
+   - The `ec2-action-builder` has a 30-minute TTL by default
+
+## Support
+
+- Packer Documentation: https://developer.hashicorp.com/packer/docs
+- AlmaLinux Cloud SIG Chat: https://chat.almalinux.org/almalinux/channels/sigcloud
+- Workflow run logs: GitHub Actions tab in the repository

--- a/GCP_IMAGE_TEST_PUBLISH.md
+++ b/GCP_IMAGE_TEST_PUBLISH.md
@@ -1,0 +1,309 @@
+# Google Cloud Platform Image Testing & Publishing
+
+## Overview
+
+This document describes the GitHub Actions workflows used to **test** and **publish** AlmaLinux OS images on Google Cloud Platform (GCP). The process is split into two independent workflows:
+
+| Workflow | File | Purpose |
+| :--- | :--- | :--- |
+| **GCP cloud-image-tests** | `test-gcp.yml` | Run Google's [Cloud Image Tests](https://github.com/GoogleCloudPlatform/cloud-image-tests) (CIT) against images in the dev project across many machine shapes |
+| **GCP Image Publish** | `gcp-publish.yml` | Copy a tested image from the dev project to the production `almalinux-cloud` project and publish its SBOM |
+
+Both workflows are triggered manually via `workflow_dispatch`.
+
+
+## GCP Projects
+
+| Project | Project ID | Role |
+| :--- | :--- | :--- |
+| Dev Images | `almalinux-dev-images-469421` | Holds newly built images for testing |
+| Image Testing | `almalinux-image-testing-469421` | Runs CIT test VMs |
+| Image Release (prod) | `almalinux-image-release` | Work project for the publish tool |
+| Production | `almalinux-cloud` | Public-facing project with released images |
+
+
+## Authentication
+
+Both workflows use **Workload Identity Federation** (no static keys) via `google-github-actions/auth@v2`.
+
+| Workflow | Workload Identity Pool | Service Account |
+| :--- | :--- | :--- |
+| Testing | `projects/527193872801/…/github-actions/providers/github` | `github-actions-image-testing@almalinux-image-testing-469421.iam.gserviceaccount.com` |
+| Publishing | `projects/1071098808632/…/github-actions/providers/github` | `gh-actions-prod-release@almalinux-image-release.iam.gserviceaccount.com` |
+
+Required GitHub permissions on the jobs: `id-token: write`, `contents: read`.
+
+
+## Image Naming Convention
+
+GCP image names follow the pattern:
+
+```
+almalinux-{version_major}[-arm64]-v{YYYYMMDD}
+```
+
+Examples:
+- `almalinux-9-v20250920` — AlmaLinux 9, x86_64
+- `almalinux-10-arm64-v20251205` — AlmaLinux 10, AArch64
+
+Image families (used for "latest" resolution in testing):
+
+```
+almalinux-{version_major}[-arm64]
+```
+
+
+## Workflow 1 — Testing (`test-gcp.yml`)
+
+### Inputs
+
+| Input | Type | Required | Default | Description |
+| :--- | :--- | :---: | :--- | :--- |
+| `version_major` | choice | ✅ | `10` | `10-kitten`, `10`, `9`, or `8` |
+| `arch` | choice | ✅ | `ALL` | `ALL`, `x86_64`, or `aarch64` |
+| `image_override` | string | ❌ | _(empty)_ | Full GCP image path to test directly, overrides `version_major` |
+
+When `image_override` is empty, the workflow resolves the latest image from the family:
+
+```
+projects/almalinux-dev-images-469421/global/images/family/almalinux-{version_major}[-arm64]
+```
+
+### Test Stages
+
+The testing workflow is organized into four sequential/parallel job groups:
+
+```mermaid
+flowchart TD
+    A[init-data] --> B[Initial Tests]
+    A --> C[Non-Per-Shape Tests]
+    B --> D[Per-Shape x86_64 Tests]
+    B --> E[Per-Shape aarch64 Tests]
+```
+
+#### 1. `init-data`
+
+Determines the GCP image path to test based on inputs. If `image_override` is provided it is used directly; otherwise the image family path is constructed.
+
+#### 2. `test-gcp-initialtest` — Initial Smoke Tests
+
+Runs a subset of CIT tests (`lssd`, `disk`, `vmspec`) with **high parallelism** (`-parallel_count 20`) to get quick feedback on obvious regressions before the full per-shape matrix runs.
+
+- Runs for each architecture in the matrix.
+- Uses fixed shapes: `c4-standard-8` (x86_64), `c4a-standard-8` (aarch64).
+
+#### 3. `test-gcp-nonpershape` — Non-Per-Shape Tests
+
+Runs CIT tests that are hard-coded to specific shapes internally (filter: `lssd`, `disk`, `vmspec`). Running these against every shape would be redundant since CIT forces specific shapes regardless.
+
+- Uses a slower stagger (`-parallel_stagger 10s`).
+
+#### 4. `test-gcp-pershape-x86_64` / `test-gcp-pershape-aarch64` — Per-Shape Tests
+
+These are the comprehensive tests that run after the initial smoke tests pass. Each test runs the full CIT filter on a specific machine shape:
+
+**CIT test filter:**
+```
+cvm|livemigrate|suspendresume|loadbalancer|guestagent|hostnamevalidation|
+imageboot|licensevalidation|network|security|hotattach|packagevalidation|ssh|metadata
+```
+
+**x86_64 shapes** (tested on self-hosted or GitHub-hosted runners):
+
+| Family | Shapes |
+| :--- | :--- |
+| N4 | `n4-standard-2`, `n4-standard-80` |
+| N2 | `n2-standard-2`, `n2-standard-128` |
+| N2D | `n2d-standard-2`, `n2d-standard-224` |
+| N1 | `n1-standard-1`, `n1-standard-96` |
+| C4 | `c4-standard-2`, `c4-standard-192` |
+| C4D | `c4d-standard-2`, `c4d-standard-192` |
+| C3 | `c3-standard-4`, `c3-standard-176` |
+| C3D | `c3d-standard-4`, `c3d-standard-360` |
+| E2 | `e2-standard-2`, `e2-standard-32`, `e2-medium` |
+| T2D | `t2d-standard-1`, `t2d-standard-60` |
+| C2 | `c2-standard-4`, `c2-standard-60` |
+| C2D | `c2d-standard-2`, `c2d-standard-112` |
+
+**aarch64 shapes:**
+
+| Shape | Notes |
+| :--- | :--- |
+| `c4a-standard-4` | General aarch64 test |
+| `t2a-standard-4` | Tau T2A family |
+| `c4a-standard-96-metal` | Metal instance (zone: `us-central1-b`, skipped for AlmaLinux 8) |
+
+### Disabled Shapes
+
+Several shapes are commented out due to:
+- **LSSD failures**: All LSSD shapes ([CIT issue #345](https://github.com/GoogleCloudPlatform/cloud-image-tests/issues/345))
+- **H4D failures**: ([CIT issue #346](https://github.com/GoogleCloudPlatform/cloud-image-tests/issues/346))
+- **Quota limitations**: M4, X4, M3, M2, M1, Z3 families
+- **Capacity issues**: Various metal and large shapes
+
+### Runner Configuration
+
+The `test-gcp-pershape-x86_64` job uses dynamic runner selection:
+- **AlmaLinux org**: Self-hosted runner via `runs-on` (AlmaLinux 10 x86_64, spot disabled)
+- **Other forks**: Falls back to `ubuntu-24.04`
+
+Self-hosted runners require Podman (installed at runtime with SELinux set to permissive), while GitHub-hosted runners use Docker.
+
+
+## Workflow 2 — Publishing (`gcp-publish.yml`)
+
+### Inputs
+
+| Input | Type | Required | Default | Description |
+| :--- | :--- | :---: | :--- | :--- |
+| `version_major` | choice | ✅ | _(empty)_ | `10-kitten`, `10`, `9`, or `8` |
+| `arch` | choice | ✅ | _(empty)_ | `x86_64` or `aarch64` |
+| `image_datetag` | string | ✅ | _(empty)_ | Date portion after `v` in image name (e.g. `20251205`) |
+
+### Publish Process
+
+```mermaid
+flowchart TD
+    A[Build image name from inputs] --> B[Authenticate with GCP]
+    B --> C["Copy root.tar.gz from dev → prod bucket"]
+    C --> D[Download gce_image_publish tool]
+    D --> E["Create production image in almalinux-cloud"]
+    E --> F[Get image ID]
+    F --> G["Copy SBOM to public SBOM bucket"]
+```
+
+#### Step-by-Step
+
+1. **Build image name** — Constructs the image name from inputs:
+   ```
+   almalinux-{version_major}[-arm64]-v{image_datetag}
+   ```
+
+2. **Copy image to production bucket** — Copies the built `root.tar.gz` from the dev bucket to the production bucket:
+   ```bash
+   gcloud storage cp \
+     gs://almalinux-images-dev/{image_name}/root.tar.gz \
+     gs://almalinux-images-prod/{image_name}/root.tar.gz
+   ```
+
+3. **Download `gce_image_publish`** — Fetches Google's pre-built image publishing tool:
+   ```bash
+   wget https://storage.googleapis.com/compute-image-tools/release/linux/gce_image_publish
+   ```
+
+4. **Create production image** — Publishes the image to the `almalinux-cloud` project using a publish template:
+   ```bash
+   ./gce_image_publish \
+     -var:environment=prod \
+     -skip_confirmation \
+     -rollout_rate=60 \
+     -work_project="almalinux-image-release" \
+     -source_gcs_path="gs://almalinux-images-prod/" \
+     -source_version="v{image_datetag}" \
+     vm-scripts/gcp/almalinux_{version_major}[_arm64].publish.json
+   ```
+
+5. **Get image ID** — Retrieves the numeric ID of the newly created image:
+   ```bash
+   gcloud compute images describe {image_name} \
+     --project=almalinux-cloud --format='value(id)'
+   ```
+
+6. **Copy SBOM** — Copies the SPDX SBOM document to the public SBOM bucket:
+   ```bash
+   gcloud storage cp \
+     gs://almalinux-images-dev-sbom/{image_name}.sbom.spdx.json \
+     gs://gce-image-almalinux-cloud-sbom/{IMAGE_ID}.json
+   ```
+
+### GCS Buckets
+
+| Bucket | Purpose |
+| :--- | :--- |
+| `almalinux-images-dev` | Dev image storage (`root.tar.gz` per image) |
+| `almalinux-images-prod` | Production image storage |
+| `almalinux-images-dev-sbom` | Dev SBOM storage |
+| `gce-image-almalinux-cloud-sbom` | Public SBOM storage (keyed by image numeric ID) |
+
+
+## Publish Templates
+
+The `gce_image_publish` tool uses Go-templated JSON configs in `vm-scripts/gcp/`:
+
+| Template | Family | Architecture |
+| :--- | :--- | :--- |
+| `almalinux_8.publish.json` | `almalinux-8` | X86_64 |
+| `almalinux_8_arm64.publish.json` | `almalinux-8-arm64` | ARM64 |
+| `almalinux_9.publish.json` | `almalinux-9` | X86_64 |
+| `almalinux_9_arm64.publish.json` | `almalinux-9-arm64` | ARM64 |
+| `almalinux_10.publish.json` | `almalinux-10` | X86_64 |
+| `almalinux_10_arm64.publish.json` | `almalinux-10-arm64` | ARM64 |
+
+### Template Environments
+
+Each template supports three environments via the `-var:environment` flag:
+
+| Environment | Publish Project | DeleteAfter |
+| :--- | :--- | :--- |
+| `test` | `almalinux-dev-images-469421` | 60 days |
+| `prod` | `almalinux-cloud` | _(never)_ |
+| _(default)_ | `gce-image-builder` | 60 days |
+
+### Guest OS Features
+
+Features vary by architecture:
+
+**x86_64** (AlmaLinux 10):
+```json
+["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE", "SEV_SNP_CAPABLE",
+ "SEV_LIVE_MIGRATABLE", "SEV_LIVE_MIGRATABLE_V2", "GVNIC", "IDPF", "TDX_CAPABLE"]
+```
+
+**x86_64** (AlmaLinux 9 — no `SEV_LIVE_MIGRATABLE_V2`):
+```json
+["UEFI_COMPATIBLE", "VIRTIO_SCSI_MULTIQUEUE", "SEV_CAPABLE", "SEV_SNP_CAPABLE",
+ "SEV_LIVE_MIGRATABLE", "GVNIC", "IDPF", "TDX_CAPABLE"]
+```
+
+**aarch64:**
+```json
+["UEFI_COMPATIBLE", "GVNIC", "IDPF"]
+```
+
+### Licenses
+
+Each image family has a license:
+```
+projects/almalinux-cloud/global/licenses/almalinux-{version_major}
+```
+
+
+## Build → Test → Publish End-to-End Flow
+
+The GCP image lifecycle spans the main build workflow and these two workflows:
+
+```mermaid
+flowchart LR
+    A["build.yml<br/>(Packer build)"] --> B["Upload root.tar.gz<br/>+ SBOM to dev buckets"]
+    B --> C["gce_image_publish<br/>(test environment)"]
+    C --> D["test-gcp.yml<br/>(CIT testing)"]
+    D --> E["gcp-publish.yml<br/>(prod release)"]
+    E --> F["Image live in<br/>almalinux-cloud"]
+```
+
+1. **Build** (`build.yml`) — Packer builds the GCP image and generates an SBOM.
+2. **Upload to dev** (shared-steps) — `root.tar.gz` and SBOM are uploaded to GCS dev buckets; a test image is created in the dev project using `gce_image_publish` with `environment=test`.
+3. **Test** (`test-gcp.yml`) — CIT tests are run against the dev image across multiple machine shapes.
+4. **Publish** (`gcp-publish.yml`) — The image is copied to the prod bucket, published to `almalinux-cloud`, and the SBOM is stored publicly.
+
+
+## Troubleshooting
+
+| Symptom | Possible Cause | Fix |
+| :--- | :--- | :--- |
+| Auth fails with "permission denied" | Workload Identity Federation misconfigured | Verify pool/provider IDs and service account IAM bindings |
+| CIT test times out | Capacity unavailable for the machine shape | Re-run or skip shape; check GCP quota dashboard |
+| `gce_image_publish` fails | Wrong environment var or missing publish template | Verify `-var:environment` and template file path |
+| SBOM copy fails | SBOM not generated during build | Ensure the build workflow ran with `IMAGE_TYPE=gcp` |
+| Image not visible in `almalinux-cloud` | Publish used wrong environment | Confirm `-var:environment=prod` was passed |
+| "No image found in family" during testing | Image not yet created in dev project | Run `build.yml` for GCP first to create the dev image |

--- a/OCI_MARKETPLACE.md
+++ b/OCI_MARKETPLACE.md
@@ -1,0 +1,413 @@
+# Oracle Cloud Marketplace Publishing
+
+## Overview
+
+This repository includes a GitHub Actions workflow for automated publishing of AlmaLinux OS images to Oracle Cloud Marketplace.
+
+> **Note:** Recently, Oracle Cloud Marketplace publishing and management was migrated to the Oracle Cloud Infrastructure (OCI) Console, replacing the previous Partner Portal. This migration made it significantly harder to discover the correct procedure and API calls for programmatic image publishing, as documentation for the new OCI Console-based workflow is sparse and the CLI options differ from what older guides describe.
+
+## Files
+
+### `.github/workflows/oci-marketplace-publish.yml`
+
+Main workflow for end-to-end publishing of AlmaLinux OS images to Oracle Cloud Marketplace.
+
+**What it does:**
+- Accepts one of three image source types: a QCOW2 file URL, an existing Compute Image OCID, or an existing Marketplace Artifact OCID
+- Validates the input format (URL pattern or OCID prefix)
+- Depending on source type, resolves the image through different paths (see [Source Type Paths](#source-type-paths) below)
+- Parses the image filename to extract version, architecture, date, and release info
+- Finds the currently published Listing Revision for the matching AlmaLinux version/architecture
+- Optionally: clones it into a new Draft Revision, creates a package linking artifact and terms, and submits for Oracle review
+- Sends Mattermost notifications and generates a GitHub Actions job summary
+
+**Usage:**
+```
+Trigger via GitHub UI: Actions → OCI Image to Marketplace release
+
+Inputs:
+  - image_source_type:      'QCOW2 file URL' | 'Compute Image OCID' | 'Artifact OCID'
+  - image_source_data:      URL or OCID corresponding to the selected source type
+  - release_to_marketplace: true/false (default: false)
+  - notify_mattermost:      true/false (default: true)
+```
+
+### Input Validation
+
+The workflow validates `image_source_data` immediately (before installing any tools) based on the selected source type:
+
+| Source Type | Validation Rule |
+|---|---|
+| `QCOW2 file URL` | Must match `^https?://.+\.qcow2$` |
+| `Compute Image OCID` | Must start with `ocid1.image.` |
+| `Artifact OCID` | Must match `^ocid1..+artifact` (e.g., `ocid1.marketplacepublisherartifact.oc1..…`) |
+
+## Source Type Paths
+
+The workflow supports three different starting points, each skipping the steps that are not needed:
+
+### 1. QCOW2 file URL (full pipeline)
+
+All steps run. The workflow downloads the image, uploads to Object Storage, imports as a Compute Image, configures capabilities and shape compatibility, creates a Marketplace Artifact, and proceeds to marketplace release.
+
+### 2. Compute Image OCID (skip download/upload/import/capabilities)
+
+Starts from an existing OCI Compute Image. The workflow:
+1. Fetches the Compute Image metadata and derives the filename
+2. Searches Object Storage for the corresponding qcow2 object
+3. Constructs the Object Storage URL for metadata parsing
+4. Skips: Download, Upload, Import, Configure Capabilities, Configure Shape Compatibility
+5. Creates a new Marketplace Artifact (if releasing)
+
+### 3. Artifact OCID (skip everything up to marketplace release)
+
+Starts from an existing Marketplace Artifact. The workflow:
+1. Fetches the Artifact data and extracts the source Compute Image OCID
+2. Fetches the Compute Image metadata (same as path 2)
+3. Resolves the Object Storage URL (same as path 2)
+4. Skips: Download, Upload, Import, Configure Capabilities, Configure Shape Compatibility, Create Artifact
+5. Uses the provided Artifact directly for marketplace release
+
+### Steps per Source Type
+
+| Step | QCOW2 | Compute Image | Artifact |
+|---|:---:|:---:|:---:|
+| Validate inputs | ✅ | ✅ | ✅ |
+| Install & Configure OCI CLI | ✅ | ✅ | ✅ |
+| Get data of Artifact | — | — | ✅ |
+| Get data of Compute Image | — | ✅ | ✅ |
+| Get Object data from Storage | — | ✅ | ✅ |
+| Parse image URL and filename | ✅ | ✅ | ✅ |
+| Download qcow2 image | ✅ | — | — |
+| Upload to OCI Object Storage | ✅ | — | — |
+| Import as OCI Compute Image | ✅ | — | — |
+| Configure Image Capabilities | ✅ | — | — |
+| Configure Image Shape Compatibility | ✅ | — | — |
+| Create the new Artifact | ✅¹ | ✅¹ | — |
+| Get Terms Collection & Version | ✅ | ✅ | ✅ |
+| Get latest Listing Revision | ✅ | ✅ | ✅ |
+| Clone → Update → Package → Submit | ✅¹ | ✅¹ | ✅¹ |
+| Print job summary | ✅ | ✅ | ✅ |
+| Send Mattermost notification | ✅² | ✅² | ✅² |
+
+¹ Only when `release_to_marketplace: true`
+² Only when `notify_mattermost: true`
+
+## Required GitHub Configuration
+
+The following secrets and variables must be configured in the repository settings.
+
+### Secrets
+| Secret | Description |
+|--------|-------------|
+| `OCI_CLI_USER` | OCI user OCID |
+| `OCI_CLI_TENANCY` | OCI tenancy OCID |
+| `OCI_CLI_FINGERPRINT` | API key fingerprint |
+| `OCI_CLI_KEY_CONTENT` | Private API key content (PEM) |
+| `OCI_COMPARTMENT_ID` | Compartment OCID where images and artifacts are created |
+| `OCI_OBJECT_STORAGE_NAMESPACE` | Object Storage namespace |
+
+### Variables (`vars.*`)
+| Variable | Description |
+|----------|-------------|
+| `OCI_CLI_REGION` | OCI region (e.g., `us-ashburn-1`) |
+| `OCI_OBJECT_STORAGE_BUCKET` | Bucket name for image uploads |
+| `MATTERMOST_CHANNEL` | Mattermost channel for notifications |
+
+### Secrets (for notifications)
+| Secret | Description |
+|--------|-------------|
+| `MATTERMOST_WEBHOOK_URL` | Mattermost incoming webhook URL |
+
+## Prerequisites
+
+Before running the workflow:
+
+1. **Create OCI Object Storage Bucket**
+   - Create a bucket for temporary image storage (if it doesn't exist)
+   - Note the bucket name and namespace
+   - Add as GitHub variable/secret respectively
+
+2. **Verify IAM Permissions**
+   The OCI API key user must have permissions for:
+   - **Object Storage**: read/write access to the bucket
+   - **Compute**: image import, image capability schema create/update
+   - **Marketplace Publisher**: artifact create/get, listing revision clone/update, package create/update, work request get
+
+3. **Ensure Published Listings Exist**
+   The workflow dynamically discovers Marketplace Listings by name pattern (e.g., `AlmaLinux OS 9 (x86_64)`). Each listing must have at least one **PUBLISHED** revision to clone from.
+
+4. **Ensure Terms Collection Exists**
+   The workflow automatically finds the most recent ACTIVE terms collection and its latest version. At least one must exist in the compartment.
+
+## Image URL and Naming Convention
+
+All three source types ultimately resolve to an Object Storage URL for metadata extraction. The workflow expects qcow2 files with this URL structure:
+```
+https://{host}/…/images/{major}/{version}/oci/{release}/{filename}
+```
+
+### URL Examples
+```
+https://example.com/images/8/8.10/oci/20260202092731/AlmaLinux-8-OCI-8.10-20260202.x86_64.qcow2
+https://example.com/images/9/9.6/oci/20260202092731/AlmaLinux-9-OCI-9.6-20260202.x86_64.qcow2
+https://example.com/images/10/10.1/oci/20260216092731/AlmaLinux-10-OCI-10.1-20260216.0.aarch64.qcow2
+```
+
+### Filename Patterns
+```
+AlmaLinux-{major}-OCI-{version}-{date}.{arch}.qcow2
+AlmaLinux-{major}-OCI-{version}-{date}.{index}.{arch}.qcow2
+```
+
+The second pattern (with `.{index}` suffix on date) is used for AlmaLinux 10+ images. It numbers the build iteration.
+
+### Extracted Metadata
+
+From **URL path** (e.g., `/images/8/8.10/oci/20260202092731/...`):
+- `ALMA_RELEASE` — release timestamp directory in path
+
+From **filename** (e.g., `AlmaLinux-8-OCI-8.10-20260202.x86_64.qcow2`):
+- `ALMA_MAJOR` — major version (e.g., `8`)
+- `ALMA_VERSION` — full version (e.g., `8.10`)
+- `ALMA_DATE` — date with optional minor suffix (e.g., `20260202` or `20260216.0`)
+- `ALMA_ARCH` — architecture (`x86_64` or `aarch64`)
+
+The `PACKAGE_VERSION` is composed as `{ALMA_VERSION}.{ALMA_DATE}` (e.g., `8.10.20260202` or `10.1.20260216.0`).
+
+### Code Names
+
+The workflow maps versions to AlmaLinux code names (used in release notes links and descriptions). The mapping is hardcoded and must be updated manually when new AlmaLinux versions are released:
+
+| Version | Code Name |
+|---------|-----------|
+| 8.10 | Cerulean Leopard |
+| 9.7 | Moss Jungle Cat |
+| 10.1 | Heliotrope Lion |
+
+## Supported Listings
+
+The workflow supports these 6 AlmaLinux OS Marketplace Listings:
+
+1. AlmaLinux OS 8 (x86_64)
+2. AlmaLinux OS 8 (AArch64)
+3. AlmaLinux OS 9 (x86_64)
+4. AlmaLinux OS 9 (AArch64)
+5. AlmaLinux OS 10 (x86_64)
+6. AlmaLinux OS 10 (AArch64/ARM64)
+
+Listings are discovered dynamically by name pattern — no hardcoded OCIDs are needed.
+
+## Workflow Process
+
+### End-to-End Flow
+
+```mermaid
+graph TD
+    A[Trigger Workflow] --> V[Validate Inputs]
+    V --> B[Install & Configure OCI CLI]
+
+    B --> ART{Source Type?}
+
+    ART -->|Artifact OCID| GA[Get data of Artifact<br/>extract Compute Image OCID]
+    GA --> GC[Get data of Compute Image<br/>derive filename]
+    ART -->|Compute Image OCID| GC
+    GC --> GO[Get Object data from Storage<br/>resolve Object URL]
+    GO --> P[Parse image URL and filename]
+
+    ART -->|QCOW2 file URL| P
+
+    P --> DL[Download qcow2 Image]
+    P --> SK1[Skip download/upload/import/capabilities]
+
+    DL --> UL[Upload to OCI Object Storage]
+    UL --> IM[Import as OCI Compute Image]
+    IM --> W1[Wait for Image AVAILABLE]
+    W1 --> CAP[Configure Image Capabilities Schema]
+    CAP --> SHP[Configure Image Shape Compatibility]
+
+    SHP --> CR[Create Marketplace Artifact]
+    SK1 --> CR
+    CR --> W2[Wait for Artifact AVAILABLE]
+
+    W2 --> T[Get Terms Collection & Version]
+    SK1 -->|Artifact OCID path| T
+
+    T --> LR[Find Published Listing Revision]
+    LR --> REL{Release to<br/>Marketplace?}
+    REL -->|No| S[Generate Summary]
+    REL -->|Yes| CL[Clone Listing Revision → Draft]
+    CL --> WC[Wait for Clone Work Request]
+    WC --> UD[Update Draft Version Details]
+    UD --> UN[Unset Default on Old Packages]
+    UN --> NP[Create New Package as Default]
+    NP --> SB[Submit Draft for Review]
+    SB --> S
+    S --> MM[Send Mattermost Notification]
+```
+
+### Image Capabilities
+
+The workflow configures the following image capabilities on every imported image (QCOW2 path only):
+
+| Capability | Value |
+|------------|-------|
+| Firmware | UEFI_64 |
+| Secure Boot | Enabled |
+| Launch Mode | PARAVIRTUALIZED |
+| Network Attachment | PARAVIRTUALIZED |
+| Boot Volume Type | PARAVIRTUALIZED |
+| Local Data Volume Type | PARAVIRTUALIZED |
+| Remote Data Volume Type | PARAVIRTUALIZED |
+| Paravirtualization Version | 2 |
+| Consistent Volume Naming | Enabled |
+| In-transit Encryption | Enabled |
+| Multipath Device Support | Enabled |
+| IPv6 Only | Enabled |
+
+These are set via the OCI Compute Image Capability Schema API, using the latest available global schema version (discovered dynamically).
+
+### Shape Compatibility
+
+After the image is imported (QCOW2 path only), the workflow configures shape compatibility entries on the Compute Image based on architecture. This is required because the Marketplace API needs Flex shapes to have explicit OCPU and memory constraints.
+
+**For aarch64:**
+1. Removes all default (x86_64) shapes from the image
+2. Adds Ampere ARM shapes:
+   - **Flex shapes** (`VM.Standard.A1.Flex`, `VM.Standard.A2.Flex`, `VM.Standard.A4.Flex`) — OCPU/memory limits are queried dynamically from `oci compute shape list`
+   - **Bare Metal shapes** (`BM.Standard.A1.160`, `BM.Standard.A4.48`) — no constraints needed
+   - `VM.Standard.Ampere.Generic` is excluded — it's an OCI alias for `A1.Flex` and adding it overwrites `A1.Flex`'s constraints
+
+**For x86_64:**
+1. Removes legacy/outdated shapes (Standard1, DenseIO1, HighIO1, Standard2T, BigData), ARM shapes (`.A1.`, `.A2.`, `.A4.`), and `*.Generic` alias shapes
+2. Configures remaining Flex shapes with OCPU/memory constraints:
+   - Each Flex shape is **removed then re-added** (because `add` silently skips shapes that already exist without updating constraints)
+   - Constraints are queried dynamically from `oci compute shape list`
+   - Shapes not available in the compartment/region or missing constraint data are removed
+
+### Marketplace Artifact
+
+Each artifact is created with:
+- `sourceImageId` — the Compute Image OCID
+- `username: "opc"` — the default SSH login user
+- `isSnapshotAllowed: true`
+- `imageShapeCompatibilityEntries` — shape compatibility entries from the Compute Image, with:
+  - `*.Generic` alias shapes filtered out (e.g., `VM.Standard.Ampere.Generic`, `VM.Standard.AMD.Generic`) — OCI adds these automatically but the Marketplace API rejects them
+  - `memoryConstraints` (`minInGBs`, `maxInGBs`) and `ocpuConstraints` (`min`, `max`) included for all Flex shapes
+
+When the source type is `Artifact OCID`, artifact creation is skipped entirely — the provided artifact is reused directly.
+
+### Listing Revision Lifecycle
+
+1. **Clone** the currently PUBLISHED revision → creates a NEW (draft) revision
+2. **Update** the draft's version details (version number, release date, release notes link), headline, and tagline
+3. **Unset default** on any existing default packages in the draft
+4. **Create** a new package as default (linking artifact + terms + version)
+5. **Submit** the draft for Oracle review
+
+After Oracle approves the revision, it must be **published manually** from the OCI Console. Publishing the new revision automatically unpublishes the previous one.
+
+## Manual Steps After Workflow Completes
+
+1. **Wait for Oracle to approve** the submitted revision (check status in OCI Console)
+2. **Publish** the approved revision from the [OCI Publisher Console](https://cloud.oracle.com/publisher) — the previous revision is automatically unpublished
+
+## Testing
+
+1. **Dry Run** (recommended for first test)
+   - Set `release_to_marketplace: false`
+   - For **QCOW2 file URL**: performs download → upload → import → capabilities → shape compatibility (no artifact, no marketplace)
+   - For **Compute Image OCID**: resolves image and Object Storage data only
+   - For **Artifact OCID**: resolves artifact, image, and Object Storage data only
+   - Verify the parsed metadata in the job summary
+
+2. **Full Run**
+   - Set `release_to_marketplace: true`
+   - Performs the complete end-to-end flow for the selected source type
+   - Monitor the workflow execution in GitHub Actions
+   - Check the draft revision in the OCI Publisher Console after completion
+
+## Troubleshooting
+
+### Common Issues
+
+1. **"Invalid URL" / "Invalid OCID" validation error**
+   - The workflow validates `image_source_data` format before doing anything else
+   - For QCOW2: must start with `http://` or `https://` and end with `.qcow2`
+   - For Compute Image OCID: must start with `ocid1.image.`
+   - For Artifact OCID: must match `ocid1.…artifact` pattern
+
+2. **"Invalid image filename format" error**
+   - Ensure the qcow2 filename follows the naming convention
+   - Both `AlmaLinux-8-OCI-8.10-20260202.x86_64.qcow2` and `AlmaLinux-10-OCI-10.1-20260216.0.aarch64.qcow2` formats are supported
+
+3. **"Failed to get artifact data" error**
+   - Verify the Artifact OCID is correct and the artifact exists in the configured compartment
+   - Ensure the OCI API key user has `marketplace-publisher artifact get` permission
+
+4. **"Failed to extract source image ID from artifact" error**
+   - The artifact must be a machine image artifact (type `OCI_COMPUTE_IMAGE`)
+   - The `machine-image.source-image-id` field must be present
+
+5. **"Image is not AVAILABLE" error**
+   - For Compute Image OCID / Artifact OCID: the referenced compute image must be in AVAILABLE state
+   - For QCOW2 imports: wait for the import to complete (up to 30 minutes)
+
+6. **"Object not found in Object Storage" error**
+   - The workflow searches Object Storage for a matching qcow2 file by prefix derived from the image display name
+   - Verify the image was previously uploaded to the expected bucket and path
+   - Check that `OCI_OBJECT_STORAGE_BUCKET` (variable) and `OCI_OBJECT_STORAGE_NAMESPACE` (secret) are correct
+
+7. **"Failed to download image" error**
+   - Verify the image URL is publicly accessible
+   - Check network connectivity from GitHub runners
+
+8. **"Image is not in QCOW format" error**
+   - The workflow verifies the downloaded file is actually a QCOW image using `file` command
+   - Ensure the URL points to a valid qcow2 file (not an HTML error page)
+
+9. **Image import timeout**
+   - Import waits up to 30 minutes (polling every 30 seconds)
+   - Large images may take longer; increase `MAX_WAIT_SECONDS` if needed
+
+10. **Image capability schema errors**
+    - The workflow dynamically discovers the latest global capability schema version
+    - If `create` fails (schema may already exist for the image), it falls back to `update`
+
+11. **"Invalid Shape … is flexible, must have memory and OCPU constraints" error**
+    - The Marketplace API requires explicit `memoryConstraints` and `ocpuConstraints` for all Flex shapes
+    - The workflow configures these automatically by querying `oci compute shape list`
+    - If a Flex shape is not available in the compartment/region, it is removed from the image
+
+12. **"Invalid Shape … does not exist" error (e.g., `VM.Standard.Ampere.Generic`)**
+    - OCI auto-adds `*.Generic` alias shapes (e.g., `VM.Standard.Ampere.Generic`, `VM.Standard.AMD.Generic`) to Compute Images
+    - The Marketplace API does not recognize these aliases
+    - The workflow filters them out using `endswith(".Generic")` in the artifact payload `jq` transformation
+
+13. **Artifact creation timeout**
+    - Artifact creation waits up to 45 minutes (polling every 30 seconds)
+    - This involves Oracle validating and processing the machine image
+
+14. **"Listing revision is not in New status" error**
+    - Packages can only be added to revisions with status `NEW` (draft)
+    - The workflow clones the PUBLISHED revision to create a NEW draft; this error means the clone or lookup failed
+
+15. **"Unknown resource" error on package creation (term-id)**
+    - Ensure the Terms Collection has an ACTIVE version
+    - The workflow passes the Term Collection ID (not the Term Version ID) to the package create command
+
+16. **"Invalid releaseDate format" error**
+    - The OCI API expects date format `EEE MMM dd yyyy` (e.g., `Sat Feb 01 2026`)
+    - The workflow formats this automatically using `date -d`
+
+### Linter Warnings
+
+GitHub Actions YAML linter may show warnings about context access for environment variables set via `$GITHUB_ENV`. These are false positives — the workflow functions correctly.
+
+## Support
+
+- OCI Publisher Console: https://cloud.oracle.com/publisher
+- OCI Marketplace Documentation: https://docs.oracle.com/en-us/iaas/Content/Marketplace/home.htm
+- Image Capabilities Documentation: https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/configuringimagecapabilities.htm
+- AlmaLinux Cloud SIG Chat: https://chat.almalinux.org/almalinux/channels/sigcloud
+- Workflow run logs: GitHub Actions tab in the repository

--- a/README.md
+++ b/README.md
@@ -24,6 +24,20 @@ AlmaLinux OS images for various cloud platforms.
 | Vagrant | `virtualbox`(`x86_64`), `libvirt`(`x86_64`, `x86_64 UEFI`), `vmware_desktop`(`x86_64`), `hyperv`(`x86_64`), `parallels`(`x86_64, AArch64`) | https://app.vagrantup.com/almalinux |
 
 
+## CI/CD Workflows
+
+This repository includes GitHub Actions workflows that automate building, testing, and publishing AlmaLinux OS images. Each workflow has detailed documentation:
+
+| Documentation | Workflows | Description |
+| :--- | :--- | :--- |
+| [BUILD_CLOUD_IMAGES.md](BUILD_CLOUD_IMAGES.md) | `build.yml`, `shared-steps/action.yml` | Main workflow that builds all cloud and Vagrant image types using Packer with a matrix strategy across multiple architectures and platforms |
+| [AWS_AMI_BUILD_COPY_RELEASE.md](AWS_AMI_BUILD_COPY_RELEASE.md) | `build-ami.yml`, `copy-ami.yml`, `ami-to-marketplace.yml` | End-to-end AWS pipeline: build AMIs with Packer, copy across all regions, and publish to AWS Marketplace |
+| [AZURE_GALLERY.md](AZURE_GALLERY.md) | `azure-to-gallery.yml` | Convert and upload images to Azure Compute Gallery with support for Gen1/Gen2 VMs and multiple architectures |
+| [OCI_MARKETPLACE.md](OCI_MARKETPLACE.md) | `oci-marketplace-publish.yml` | Import images into Oracle Cloud Infrastructure and publish to the OCI Marketplace |
+| [GCP_IMAGE_TEST_PUBLISH.md](GCP_IMAGE_TEST_PUBLISH.md) | `test-gcp.yml`, `gcp-publish.yml` | Test GCP images across many machine shapes using Cloud Image Tests, then publish to the `almalinux-cloud` project |
+| [VAGRANT_CLOUD.md](VAGRANT_CLOUD.md) | `vagrant-cloud-publish.yaml` | Publish Vagrant boxes to Vagrant Cloud for VirtualBox, libvirt, and VMware Desktop providers |
+
+
 ## Usage
 
 Make sure the required Packer plugins are installed and the latest:

--- a/VAGRANT_CLOUD.md
+++ b/VAGRANT_CLOUD.md
@@ -1,0 +1,212 @@
+# Vagrant Cloud Publishing
+
+## Overview
+
+This repository includes a GitHub Actions workflow for publishing AlmaLinux OS Vagrant boxes to Vagrant Cloud (via HashiCorp Cloud Platform).
+
+## Files
+
+### `.github/workflows/vagrant-cloud-publish.yaml`
+
+Workflow for publishing Vagrant box images to Vagrant Cloud.
+
+**What it does:**
+- Accepts a URL to a `.box` image file
+- Parses the filename to extract version, provider, architecture, and date
+- Downloads the box file and validates it (gzip integrity check)
+- Authenticates to HashiCorp Cloud Platform (HCP) using service principal credentials
+- Computes SHA-256 checksum of the box file
+- Publishes the box to Vagrant Cloud using `vagrant cloud publish` with direct upload
+- Automatically releases the published version
+- Supports dry-run mode for testing without uploading
+- Sends Mattermost notifications and generates job summaries
+
+**Usage:**
+```
+Trigger via GitHub UI: Actions → Vagrant Cloud publish
+
+Inputs:
+  - image_url:         URL to the .box image file (required)
+  - dry-run-mode:      Dry-run mode (default: true)
+  - notify_mattermost: Send notification to Mattermost (default: false)
+```
+
+## Required GitHub Configuration
+
+### Secrets
+| Secret | Description |
+|--------|-------------|
+| `HCP_CLIENT_ID` | HashiCorp Cloud Platform service principal client ID |
+| `HCP_CLIENT_SECRET` | HashiCorp Cloud Platform service principal client secret |
+| `GIT_HUB_TOKEN` | GitHub PAT (used for Packer GitHub API token) |
+| `MATTERMOST_WEBHOOK_URL` | Mattermost incoming webhook URL |
+
+### Variables (`vars.*`)
+| Variable | Description |
+|----------|-------------|
+| `HCP_ORG` | HCP organization name for Vagrant Cloud (e.g., `almalinux`) |
+| `MATTERMOST_CHANNEL` | Mattermost channel for notifications |
+
+## Prerequisites
+
+1. **HashiCorp Cloud Platform Service Principal**
+   - Create an HCP service principal with permissions to manage Vagrant boxes
+   - The workflow authenticates via `hcp auth login` using client ID and secret, then obtains a `VAGRANT_CLOUD_TOKEN`
+
+2. **Vagrant Cloud Boxes**
+   - Boxes must already exist in Vagrant Cloud under the HCP organization
+   - The workflow creates new **versions** of existing boxes — it does not create boxes from scratch
+
+3. **Box Naming Convention**
+   - Box names on Vagrant Cloud follow the pattern: `{HCP_ORG}/{version_major}` with optional suffixes
+   - See [Box Name Mapping](#box-name-mapping) for details
+
+## Box Filename Patterns
+
+The workflow supports two filename formats:
+
+### Modern / Kitten Format
+```
+AlmaLinux-{major|Kitten}-Vagrant-{provider}-{version}-{date}.{index}.{arch}[_v2].box
+```
+
+Examples:
+```
+AlmaLinux-9-Vagrant-virtualbox-9.6-20250522.0.x86_64.box
+AlmaLinux-9-Vagrant-libvirt-9.6-20250522.0.aarch64.box
+AlmaLinux-10-Vagrant-virtualbox-10.1-20260216.0.x86_64.box
+AlmaLinux-10-Vagrant-vmware-10.1-20260216.0.x86_64_v2.box
+AlmaLinux-Kitten-Vagrant-libvirt-10-20250813.0.x86_64.box
+```
+
+**Note:** The `_v2` suffix (x86_64_v2 microarchitecture) is available for AlmaLinux 10 and Kitten 10 only.
+
+### Legacy Format (AlmaLinux 8)
+```
+AlmaLinux-{major}-Vagrant-{version}-{date}.{arch}.{provider}.box
+```
+
+Examples:
+```
+AlmaLinux-8-Vagrant-8.10-20260202.x86_64.virtualbox.box
+AlmaLinux-8-Vagrant-8.10-20260202.aarch64.libvirt.box
+```
+
+### Extracted Metadata
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| `version_major` | Box name identifier with suffixes | `9`, `10-kitten`, `10-x86_64_v2` |
+| `vagrant_provider` | Vagrant provider name | `virtualbox`, `libvirt`, `vmware_desktop` |
+| `release_version` | AlmaLinux version | `9.6`, `10.1`, `10` |
+| `date_stamp` | Build date (index stripped for non-Kitten) | `20250522`, `20250813.0` |
+| `architecture` | CPU architecture | `x86_64`, `aarch64` |
+
+**Note:** The provider name `vmware` in the filename is automatically remapped to `vmware_desktop` (the correct Vagrant provider name).
+
+## Box Name Mapping
+
+The Vagrant Cloud box name is constructed as `{HCP_ORG}/{version_major}`, where `version_major` is built from the parsed metadata:
+
+| Source | Major | Kitten? | v2 Suffix? | `version_major` | Full Box Name |
+|--------|-------|---------|------------|-----------------|---------------|
+| AlmaLinux 8 | 8 | No | No | `8` | `{org}/8` |
+| AlmaLinux 9 | 9 | No | No | `9` | `{org}/9` |
+| AlmaLinux 10 | 10 | No | No | `10` | `{org}/10` |
+| AlmaLinux 10 (v2) | 10 | No | Yes | `10-x86_64_v2` | `{org}/10-x86_64_v2` |
+| Kitten 10 | 10 | Yes | No | `10-kitten` | `{org}/10-kitten` |
+| Kitten 10 (v2) | 10 | Yes | Yes | `10-kitten-x86_64_v2` | `{org}/10-kitten-x86_64_v2` |
+
+The box **version** on Vagrant Cloud is `{release_version}.{date_stamp}` (e.g., `9.6.20250522` or `10.20250813.0`).
+
+## Supported Providers
+
+| Provider in Filename | Vagrant Provider Name | Description |
+|---------------------|----------------------|-------------|
+| `virtualbox` | `virtualbox` | Oracle VirtualBox |
+| `libvirt` | `libvirt` | KVM/QEMU via libvirt |
+| `vmware` | `vmware_desktop` | VMware Desktop (Fusion/Workstation) |
+
+## Workflow Process
+
+```mermaid
+graph TD
+    A[Trigger Workflow with .box URL] --> B[Parse Box Filename]
+    B --> C{Dry-Run?}
+    C -->|Yes| D[Skip Download]
+    C -->|No| E[Download .box File]
+    E --> F[Validate gzip Integrity]
+    F --> G[Compute SHA-256 Checksum]
+    D --> H[Use Dummy Checksum]
+    G --> I[Authenticate to HCP]
+    H --> I
+    I --> J[Get Vagrant Cloud Token]
+    J --> K{Dry-Run?}
+    K -->|Yes| L[Print vagrant cloud publish Command]
+    K -->|No| M[Execute vagrant cloud publish]
+    M --> N[Box Version Released on Vagrant Cloud]
+    L --> O[Generate Summary & Notify]
+    N --> O
+```
+
+### Publish Details
+
+The `vagrant cloud publish` command is called with:
+
+| Flag | Description |
+|------|-------------|
+| `-C sha256` | Checksum type |
+| `-c {checksum}` | SHA-256 checksum of the box file |
+| `--release` | Automatically release the version after upload |
+| `-a {arch}` | Architecture (`amd64` or `arm64`) |
+| `--direct-upload` | Upload directly to Vagrant Cloud storage |
+| `--debug` | Enable debug output |
+| `-f` | Force overwrite if version already exists |
+
+**Note:** The architecture is remapped from the filename convention: `x86_64` → `amd64`, `aarch64` → `arm64`.
+
+## Testing
+
+1. **Dry-Run Mode** (default)
+   - Set `dry-run-mode: true`
+   - Skips downloading the box file
+   - Uses a dummy checksum (`xxx...`)
+   - Prints the `vagrant cloud publish` command without executing it
+   - Useful for verifying filename parsing and parameter generation
+
+2. **Actual Publish**
+   - Set `dry-run-mode: false`
+   - Downloads, validates, checksums, and uploads the box to Vagrant Cloud
+   - The version is automatically released upon successful upload
+
+## Troubleshooting
+
+### Common Issues
+
+1. **"No pattern matched for filename" error**
+   - The box filename doesn't match either the modern or legacy pattern
+   - Check for typos in the filename or unexpected characters
+
+2. **Download or gzip validation fails**
+   - Verify the image URL is publicly accessible
+   - Ensure the file is a valid gzip-compressed Vagrant box
+
+3. **HCP authentication fails**
+   - Verify `HCP_CLIENT_ID` and `HCP_CLIENT_SECRET` secrets are correct
+   - Ensure the service principal has Vagrant Cloud permissions
+
+4. **`vagrant cloud publish` fails**
+   - Ensure the box already exists in Vagrant Cloud under `{HCP_ORG}/{version_major}`
+   - Check that the provider name is valid
+   - If a version already exists, the `-f` flag should handle overwriting
+
+5. **Box download runs out of disk space**
+   - The workflow downloads to `/mnt` which has ~70 GB on GitHub runners
+   - Ensure the box file fits within this limit
+
+## Support
+
+- Vagrant Cloud (HCP): https://portal.cloud.hashicorp.com/vagrant/discover
+- Vagrant Documentation: https://developer.hashicorp.com/vagrant/docs
+- AlmaLinux Cloud SIG Chat: https://chat.almalinux.org/almalinux/channels/sigcloud
+- Workflow run logs: GitHub Actions tab in the repository


### PR DESCRIPTION
- `BUILD_CLOUD_IMAGES.md` - Main workflow that builds all cloud and Vagrant image types using Packer with a matrix strategy across multiple architectures and platforms
- `AWS_AMI_BUILD_COPY_RELEASE.md` - End-to-end AWS pipeline: build AMIs with Packer, copy across all regions, and publish to AWS Marketplace
- `AZURE_GALLERY.md` - Convert and upload images to Azure Compute Gallery with support for Gen1/Gen2 VMs and multiple architectures
- `OCI_MARKETPLACE.md` - Import images into Oracle Cloud Infrastructure and publish to the OCI Marketplace
- `GCP_IMAGE_TEST_PUBLISH.md` - Test GCP images across many machine shapes using Cloud Image Tests, then publish to the `almalinux-cloud` project
- `VAGRANT_CLOUD.md` - Publish Vagrant boxes to Vagrant Cloud for VirtualBox, libvirt, and VMware Desktop providers