### PR TITLE
fix(ansible): pin community.general to <12.0.0 for AL8 support

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,8 +1,12 @@
 ---
 collections:
-  - ansible.posix
-  - almalinux.ci
-  - community.general
+  - name: ansible.posix
+  - name: almalinux.ci
+  # community.general 12.x switched ini_file.py (and others) to
+  # `from __future__ import annotations`, which requires Python 3.7+.
+  # AlmaLinux 8 guests ship Python 3.6, so pin to the 11.x branch.
+  - name: community.general
+    version: "<12.0.0"
 
 roles:
-  - ezamriy.vbox_guest
+  - name: ezamriy.vbox_guest


### PR DESCRIPTION
`community.general` 12.0.0 replaced the py2/py3-compat `from __future__ import absolute_import, division, print_function` header in plugins/modules/ini_file.py (and other modules) with `from __future__ import annotations`, which requires Python 3.7+.

AlmaLinux 8 guests ship system Python 3.6, so Ansible fails with `SyntaxError: future feature annotations is not defined` when it runs any affected module on the target. Pin to the 11.x branch until AL8 support is no longer needed.

Converts the three collection entries to the dict form so the version constraint can be expressed.