### PR TITLE
Fix gencloud shrink ppc64le s390x images

### DIFF
--- a/ansible/roles/gencloud_guest/tasks/main.yml
+++ b/ansible/roles/gencloud_guest/tasks/main.yml
@@ -5,6 +5,16 @@
     regexp: "^(DEFAULTKERNEL=).*$"
     replace: "\\1kernel"
 
+# linux-firmware is pulled in by kernel-core's hard `Requires:` even though
+# the ppc64le kickstart excludes -iwl*-firmware. The package ships ~1.5 GiB
+# of firmware that is irrelevant on POWER guests. The other GenericCloud
+# arches keep it for now; only ppc64le pays the size penalty.
+- name: Remove linux-firmware on ppc64le
+  when: ansible_facts['architecture'] == 'ppc64le'
+  ansible.builtin.dnf:
+    name: linux-firmware
+    state: absent
+
 # https://bugzilla.redhat.com/show_bug.cgi?id=1849082#c7
 - name: Enabled Xen Project PVHVM drivers only on x86_64
   when: ansible_facts['architecture'] == 'x86_64'

--- a/http/almalinux-10.gencloud-s390x.ks
+++ b/http/almalinux-10.gencloud-s390x.ks
@@ -183,4 +183,14 @@ cat /dev/null > /etc/machine-id
 # The system should start out with an empty file.
 truncate -s 0 /etc/resolv.conf
 
+# Compact the image: zero out free space so post-build qemu-img convert
+# (or virt-sparsify) can drop unused clusters and produce a small qcow2.
+# The s390x build pipeline does not run packer/cleanup_vm, so do it here.
+echo "Zero-filling free space on / and /boot for image compaction."
+sync
+dd if=/dev/zero of=/zerofill bs=1M oflag=direct status=none || rm -f /zerofill
+dd if=/dev/zero of=/boot/zerofill bs=1M oflag=direct status=none || rm -f /boot/zerofill
+sync
+fstrim -av 2>/dev/null || true
+
 %end

--- a/http/almalinux-8.gencloud-s390x.ks
+++ b/http/almalinux-8.gencloud-s390x.ks
@@ -267,4 +267,14 @@ cat /dev/null > /etc/machine-id
 # The system should start out with an empty file.
 truncate -s 0 /etc/resolv.conf
 
+# Compact the image: zero out free space so post-build qemu-img convert
+# (or virt-sparsify) can drop unused clusters and produce a small qcow2.
+# The s390x build pipeline does not run packer/cleanup_vm, so do it here.
+echo "Zero-filling free space on / and /boot for image compaction."
+sync
+dd if=/dev/zero of=/zerofill bs=1M oflag=direct status=none || rm -f /zerofill
+dd if=/dev/zero of=/boot/zerofill bs=1M oflag=direct status=none || rm -f /boot/zerofill
+sync
+fstrim -av 2>/dev/null || true
+
 %end

--- a/http/almalinux-9.gencloud-s390x.ks
+++ b/http/almalinux-9.gencloud-s390x.ks
@@ -184,4 +184,14 @@ cat /dev/null > /etc/machine-id
 # The system should start out with an empty file.
 truncate -s 0 /etc/resolv.conf
 
+# Compact the image: zero out free space so post-build qemu-img convert
+# (or virt-sparsify) can drop unused clusters and produce a small qcow2.
+# The s390x build pipeline does not run packer/cleanup_vm, so do it here.
+echo "Zero-filling free space on / and /boot for image compaction."
+sync
+dd if=/dev/zero of=/zerofill bs=1M oflag=direct status=none || rm -f /zerofill
+dd if=/dev/zero of=/boot/zerofill bs=1M oflag=direct status=none || rm -f /boot/zerofill
+sync
+fstrim -av 2>/dev/null || true
+
 %end

--- a/http/almalinux-kitten-10.gencloud-s390x.ks
+++ b/http/almalinux-kitten-10.gencloud-s390x.ks
@@ -183,4 +183,14 @@ cat /dev/null > /etc/machine-id
 # The system should start out with an empty file.
 truncate -s 0 /etc/resolv.conf
 
+# Compact the image: zero out free space so post-build qemu-img convert
+# (or virt-sparsify) can drop unused clusters and produce a small qcow2.
+# The s390x build pipeline does not run packer/cleanup_vm, so do it here.
+echo "Zero-filling free space on / and /boot for image compaction."
+sync
+dd if=/dev/zero of=/zerofill bs=1M oflag=direct status=none || rm -f /zerofill
+dd if=/dev/zero of=/boot/zerofill bs=1M oflag=direct status=none || rm -f /boot/zerofill
+sync
+fstrim -av 2>/dev/null || true
+
 %end


### PR DESCRIPTION
- Remove `linux-firmware` on `ppc64le`
- Zero-fill free space for `s390x` image compaction