### PR TITLE
fix(ansible): install Parallels Tools on Vagrant Parallels boxes

### DIFF
--- a/ansible/roles/parallels_guest/README.md
+++ b/ansible/roles/parallels_guest/README.md
@@ -1,0 +1,8 @@
+# parallels_guest
+
+An Ansible role that installs Parallels Tools on a Vagrant box built with the
+Packer `parallels-iso` builder. The builder uploads the Tools ISO to
+`/home/vagrant/prl-tools-<flavor>.iso`; this role mounts it, runs the
+unattended installer, and cleans up.
+
+Required for working `prl_fs` (shared folders), `prl_eth`, and time sync.

--- a/ansible/roles/parallels_guest/meta/main.yml
+++ b/ansible/roles/parallels_guest/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  role_name: parallels_guest
+  description: Installs Parallels Tools from the Tools ISO uploaded by the Packer parallels-iso builder
+  license: MIT
+  min_ansible_version: 2.5
+  platforms:
+    - name: EL
+      versions:
+        - 8
+        - 9
+        - 10
+  galaxy_tags:
+    - guest
+    - system
+    - parallels
+
+dependencies: []

--- a/ansible/roles/parallels_guest/tasks/main.yml
+++ b/ansible/roles/parallels_guest/tasks/main.yml
@@ -1,0 +1,42 @@
+---
+- name: Locate the Parallels Tools ISO
+  find:
+    paths: /home/vagrant
+    patterns: "prl-tools-*.iso"
+  register: prl_tools_iso
+
+- name: Fail if the Parallels Tools ISO is missing
+  assert:
+    that: prl_tools_iso.matched > 0
+    fail_msg: "Parallels Tools ISO not found in /home/vagrant. Did parallels-iso builder upload it?"
+
+- name: Create mount point for the Parallels Tools ISO
+  file:
+    path: /mnt/prl-tools
+    state: directory
+    mode: "0755"
+
+- name: Mount the Parallels Tools ISO
+  command: mount -o loop,ro {{ prl_tools_iso.files[0].path | quote }} /mnt/prl-tools
+  args:
+    creates: /mnt/prl-tools/install
+
+- name: Install Parallels Tools (unattended)
+  command: /mnt/prl-tools/install --install-unattended-with-deps
+  args:
+    creates: /usr/lib/parallels-tools/version
+
+- name: Unmount the Parallels Tools ISO
+  command: umount /mnt/prl-tools
+  args:
+    removes: /mnt/prl-tools/install
+
+- name: Remove the Parallels Tools mount point
+  file:
+    path: /mnt/prl-tools
+    state: absent
+
+- name: Remove the Parallels Tools ISO
+  file:
+    path: "{{ prl_tools_iso.files[0].path }}"
+    state: absent

--- a/ansible/vagrant.yml
+++ b/ansible/vagrant.yml
@@ -14,6 +14,8 @@
       when: packer_provider == 'virtualbox-iso'
     - role: vmware_guest
       when: packer_provider == 'vmware-iso'
+    - role: parallels_guest
+      when: packer_provider == 'parallels-iso'
     - role: qemu_guest
       when: packer_provider == 'qemu'
     - role: hyperv_guest


### PR DESCRIPTION
## Summary

- Adds `parallels_guest` Ansible role that mounts the Parallels Tools ISO uploaded by the `parallels-iso` Packer builder and runs the unattended installer.
- Wires it into `ansible/vagrant.yml` gated on `packer_provider == 'parallels-iso'`, alongside the existing per-provider guest roles (vbox/vmware/qemu/hyperv).
- Fixes #163 — Vagrant Parallels boxes shipped without Parallels Tools, so `/vagrant` shared folder mount failed with `unknown filesystem type 'prl_fs'`.

## Why no build dependencies?

Parallels Tools 26.3.2 on aarch64 is fully userspace — shared folders are FUSE-based (`fuse.prl_fsd`), and `prltoolsd` / `prltimesync` cover the rest. No kernel modules are built or loaded:

```
$ lsmod | grep -i prl    # empty
$ find /lib/modules -name 'prl_*'    # empty
$ mount | grep /vagrant
vagrant on /vagrant type fuse.prl_fsd ...
```

The installer's `--install-unattended-with-deps` flag pulls what it needs via dnf (just `make` in practice). An earlier draft of this role pre-installed `gcc`, `kernel-devel`, `kernel-headers`, `perl` — all unused on aarch64, ~160 MB of dead weight in the box. They were dropped after empirical verification.

x86_64 was not tested in this PR; if a future build exercises the `lin` flavor and needs kmods, the dnf step can be reintroduced gated on `ansible_architecture`.

## Test plan

Verified on aarch64 across all three Vagrant Parallels targets:

- [x] AlmaLinux 9: `packer build -only=parallels-iso.almalinux-9-aarch64 .`
- [x] AlmaLinux 10: `packer build -only=parallels-iso.almalinux_10_vagrant_parallels_aarch64 .`
- [x] AlmaLinux Kitten 10: `packer build -only=parallels-iso.almalinux_kitten_10_vagrant_parallels_aarch64 .`

For each box: `vagrant up --provider=parallels` succeeds, `/vagrant` mounts as `fuse.prl_fsd`, host→guest read and guest→host write both round-trip. Tools version `26.3.2.57398` installed in all three.