### PR TITLE
chore(ci): follow ec2-action-builder rename NextChapterSoftware -> unblocked, bump to v1.12

### DIFF
--- a/.github/workflows/azure-build.yml
+++ b/.github/workflows/azure-build.yml
@@ -132,7 +132,7 @@ jobs:
     steps:
     - name: Setup and start runner
       if: github.repository_owner != 'AlmaLinux'
-      uses: NextChapterSoftware/ec2-action-builder@v1.10
+      uses: unblocked/ec2-action-builder@v1.12
       with:
         github_token: ${{ secrets.GIT_HUB_TOKEN }}
         aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/gcp-build.yml
+++ b/.github/workflows/gcp-build.yml
@@ -118,7 +118,7 @@ jobs:
     steps:
     - name: Setup and start runner
       if: github.repository_owner != 'AlmaLinux'
-      uses: NextChapterSoftware/ec2-action-builder@v1.10
+      uses: unblocked/ec2-action-builder@v1.12
       with:
         github_token: ${{ secrets.GIT_HUB_TOKEN }}
         aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/gencloud-build.yml
+++ b/.github/workflows/gencloud-build.yml
@@ -133,7 +133,7 @@ jobs:
     steps:
     - name: Setup and start runner
       if: github.repository_owner != 'AlmaLinux'
-      uses: NextChapterSoftware/ec2-action-builder@v1.10
+      uses: unblocked/ec2-action-builder@v1.12
       with:
         github_token: ${{ secrets.GIT_HUB_TOKEN }}
         aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/oci-build.yml
+++ b/.github/workflows/oci-build.yml
@@ -122,7 +122,7 @@ jobs:
     steps:
     - name: Setup and start runner
       if: github.repository_owner != 'AlmaLinux'
-      uses: NextChapterSoftware/ec2-action-builder@v1.10
+      uses: unblocked/ec2-action-builder@v1.12
       with:
         github_token: ${{ secrets.GIT_HUB_TOKEN }}
         aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/opennebula-build.yml
+++ b/.github/workflows/opennebula-build.yml
@@ -132,7 +132,7 @@ jobs:
     steps:
     - name: Setup and start runner
       if: github.repository_owner != 'AlmaLinux'
-      uses: NextChapterSoftware/ec2-action-builder@v1.10
+      uses: unblocked/ec2-action-builder@v1.12
       with:
         github_token: ${{ secrets.GIT_HUB_TOKEN }}
         aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/vagrant-build.yml
+++ b/.github/workflows/vagrant-build.yml
@@ -216,7 +216,7 @@ jobs:
     steps:
     - name: Setup and start runner
       if: inputs.self_hosted_runner == 'aws-ec2' && github.repository_owner != 'AlmaLinux'
-      uses: NextChapterSoftware/ec2-action-builder@v1.10
+      uses: unblocked/ec2-action-builder@v1.12
       with:
         github_token: ${{ secrets.GIT_HUB_TOKEN }}
         aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION

The `NextChapterSoftware` GitHub org was renamed to `unblocked`, and GitHub's redirect for renamed repos doesn't always resolve from inside `uses:` references in Actions workflows. Update every reference to the new owner and bump the pin to the current tag.

Affected workflows (all use the action to start an EC2 self-hosted runner for aarch64 builds outside the AlmaLinux org):

  - .github/workflows/azure-build.yml
  - .github/workflows/gcp-build.yml
  - .github/workflows/gencloud-build.yml
  - .github/workflows/oci-build.yml
  - .github/workflows/opennebula-build.yml
  - .github/workflows/vagrant-build.yml

Each file had a single line of the form
`uses: NextChapterSoftware/ec2-action-builder@v1.10` replaced with `uses: unblocked/ec2-action-builder@v1.12`. No other changes.